### PR TITLE
feat: add kural skill command and AI editors support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, alpha]
   pull_request:
-    branches: [main]
+    branches: [main, alpha]
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ The role text follows the same description principles as KURAL.md:
 - `node dist/cli.mjs` — run the built CLI
 - `vp check` — format, lint, type check
 - `vp test` — run tests (vitest, import from `vite-plus/test`)
+- `vp run docs:dev` — run docs site dev server (extracts embeddings, builds search index, starts Vite)
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ kural score
 kural audit
 ```
 
-14 statistical audits surface outliers, duplicates, containment problems, and more.
+15 statistical audits surface outliers, duplicates, containment problems, and more.
 
 ## Commands
 

--- a/docs-site/src/routes/index.tsx
+++ b/docs-site/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { HomeLayout } from "fumadocs-ui/layouts/home";
 import { BlinkingOwl, NavLogo } from "@/components/nav-logo";
 import { EmbeddingSpace } from "@/components/embedding-space";
 import { AnimatedBg } from "@/components/animated-bg";
-import { Sparkles } from "lucide-react";
+import { ChevronRight, Sparkles } from "lucide-react";
 
 export const Route = createFileRoute("/")({
   component: Home,
@@ -33,15 +33,7 @@ function Home() {
               <Sparkles className="w-3.5 h-3.5 text-fd-primary inline" />
               <span className="text-fd-primary">A Necessity</span> for Agentic Coding
             </span>
-            <svg
-              className="w-3.5 h-3.5 text-fd-muted-foreground group-hover:text-fd-primary group-hover:translate-x-0.5 transition-all duration-300"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-            </svg>
+            <ChevronRight className="w-3.5 h-3.5 text-fd-muted-foreground group-hover:text-fd-primary group-hover:translate-x-0.5 transition-all duration-300" />
           </Link>
           <p className="text-[11px] uppercase tracking-[0.08em] mb-3 text-[hsl(187,50%,35%)] dark:text-[hsl(187,40%,55%)]">
             Structural scoring for TypeScript

--- a/docs-site/src/routes/index.tsx
+++ b/docs-site/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { HomeLayout } from "fumadocs-ui/layouts/home";
 import { BlinkingOwl, NavLogo } from "@/components/nav-logo";
 import { EmbeddingSpace } from "@/components/embedding-space";
 import { AnimatedBg } from "@/components/animated-bg";
+import { Sparkles } from "lucide-react";
 
 export const Route = createFileRoute("/")({
   component: Home,
@@ -20,6 +21,28 @@ function Home() {
 
         {/* Right: Hero content */}
         <div className="flex-1 flex flex-col justify-center px-8 md:px-16 lg:px-24">
+          <Link
+            to="/docs/$"
+            params={{ _splat: "ai-editors" }}
+            className="group inline-flex items-center gap-3 w-fit mb-6 px-1.5 py-1.5 pr-4 rounded-full border border-fd-border/60 bg-fd-muted/40 backdrop-blur-sm hover:border-fd-primary/40 transition-all duration-300"
+          >
+            <span className="px-2.5 py-1 rounded-full bg-fd-primary/15 text-fd-primary text-[10px] uppercase tracking-[0.08em] font-semibold">
+              New
+            </span>
+            <span className="text-[13px] text-fd-foreground font-semibold group-hover:text-fd-foreground transition-colors duration-300 inline-flex items-center gap-1.5">
+              <Sparkles className="w-3.5 h-3.5 text-fd-primary inline" />
+              <span className="text-fd-primary">A Necessity</span> for Agentic Coding
+            </span>
+            <svg
+              className="w-3.5 h-3.5 text-fd-muted-foreground group-hover:text-fd-primary group-hover:translate-x-0.5 transition-all duration-300"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </Link>
           <p className="text-[11px] uppercase tracking-[0.08em] mb-3 text-[hsl(187,50%,35%)] dark:text-[hsl(187,40%,55%)]">
             Structural scoring for TypeScript
           </p>

--- a/docs-site/src/styles/app.css
+++ b/docs-site/src/styles/app.css
@@ -92,6 +92,11 @@ samp {
   border-top: 1px solid var(--color-fd-border);
 }
 
+/* ── Collapse paragraph margin inside Steps ── */
+.fd-step > p {
+  margin: 0;
+}
+
 /* ── Spacing fix ── */
 #nd-page > div:last-child {
   margin-top: 10rem;

--- a/docs-site/vite.docs.config.ts
+++ b/docs-site/vite.docs.config.ts
@@ -33,7 +33,8 @@ function docsDataPlugin(): Plugin {
 
       type TreeNode =
         | { type: "page"; name: string; url: string; icon?: string; $ref: { file: string } }
-        | { type: "folder"; name: string; icon?: string; children: TreeNode[] };
+        | { type: "folder"; name: string; icon?: string; children: TreeNode[] }
+        | { type: "separator"; name: string };
 
       // Resolve Lucide icon names to SVG strings at build time
       const { icons } = await import("lucide-react");
@@ -130,7 +131,13 @@ function docsDataPlugin(): Plugin {
         }
 
         // Add ordered entries first, then remaining files
+        const separatorRe = /^---(?:\[(?<icon>[^\]]+)])?(?<label>.+)---$/;
         for (const name of order) {
+          const sep = separatorRe.exec(name);
+          if (sep?.groups?.label) {
+            nodes.push({ type: "separator", name: sep.groups.label });
+            continue;
+          }
           addEntry(name);
         }
         for (const entry of readdirSync(dir)) {

--- a/docs/ai-editors.mdx
+++ b/docs/ai-editors.mdx
@@ -1,0 +1,84 @@
+---
+title: AI Code Editors
+description: A must-have tool for agentic coding — give your AI assistant structural awareness
+icon: Bot
+---
+
+## Why this matters
+
+AI coding agents write code. They add functions, create files, move things around. But they have no idea whether the code they just wrote landed in the right place. They can't see that the function they added to `utils/` is semantically identical to one in `core/`, or that the file they created in `commands/` drifts toward the analysis engine's vocabulary.
+
+Kural gives your codebase a structural map. **Kural skills give your AI assistant the ability to read that map.**
+
+Without skills, the agent generates code blind to structure. With skills, it knows the four-phase resolution pipeline, understands why descriptions carry 50% weight in the identity vector, and can work through audit findings methodically — fixing docs before restructuring, restructuring before suppressing.
+
+This is the difference between an agent that writes code and an agent that writes code **in the right place**.
+
+<Callout type="warn">
+  An AI agent without structural awareness will accumulate architectural debt faster than a human
+  developer — it produces more code per hour but has zero intuition about where that code belongs.
+  Kural skills are the structural intuition layer.
+</Callout>
+
+## Supported editors
+
+| Editor         | Skills directory    |
+| :------------- | :------------------ |
+| Claude Code    | `.claude/skills/`   |
+| Cursor         | `.agents/skills/`   |
+| Windsurf       | `.windsurf/skills/` |
+| Codex          | `.agents/skills/`   |
+| Gemini CLI     | `.agents/skills/`   |
+| GitHub Copilot | `.agents/skills/`   |
+| Cline          | `.cline/skills/`    |
+| Amp            | `.agents/skills/`   |
+| Roo Code       | `.roo/skills/`      |
+| Kilo Code      | `.kilocode/skills/` |
+| Continue       | `.continue/skills/` |
+| Goose          | `.goose/skills/`    |
+| OpenCode       | `.agents/skills/`   |
+| Trae           | `.trae/skills/`     |
+| Junie          | `.junie/skills/`    |
+| Kiro CLI       | `.kiro/skills/`     |
+| Zencoder       | `.zencoder/skills/` |
+| Qwen Code      | `.qwen/skills/`     |
+
+## Install skills
+
+Run the interactive command and select your editors:
+
+```bash
+kural skill
+```
+
+The command reads the shared skill source from `.claude/skills/resolve-audit/` and writes editor-native versions to each selected editor's skills directory. Editors that share the same directory (e.g., Cursor, Codex, Gemini CLI, GitHub Copilot, Amp, and OpenCode all use `.agents/skills/`) are deduplicated automatically.
+
+## What the skill teaches
+
+The **resolve-audit** skill gives your AI assistant the full context it needs to work through audit findings:
+
+- **The four-phase pipeline** — fix incomplete docs first, then documentation quality, then structural issues, and only suppress with `@kuralResidual` as a last resort
+- **Per-audit resolution guidance** — what each of the 15 audits detects and how to fix it
+- **Description principles** — the five rules for writing descriptions that produce accurate embeddings
+- **Kural params** — when and how to use `@kuralHelper`, `@kuralUtil`, `@kuralPatterns`, `@kuralCompanion`, `@kuralBound`, `@kuralBorrows`, `@kuralPure`, `@kuralCauses`, and `@kuralResidual`
+
+## Claude Code usage
+
+In Claude Code, the skill is invoked as a slash command:
+
+```
+/resolve-audit
+/resolve-audit outliers
+/resolve-audit src/analysis
+```
+
+For other editors, the skill content is loaded as context when your assistant detects audit-related work.
+
+## Keeping skills in sync
+
+Skill source lives in `.claude/skills/resolve-audit/`. If you update the source files, re-run `kural skill` to propagate changes to all editor targets.
+
+<Callout type="info">
+  Add editor-specific skill directories to `.gitignore` if you don't want them committed. The
+  canonical source is always `.claude/skills/resolve-audit/`.
+</Callout>

--- a/docs/ai-editors.mdx
+++ b/docs/ai-editors.mdx
@@ -51,11 +51,11 @@ Run the interactive command and select your editors:
 kural skill
 ```
 
-The command reads the shared skill source from `.claude/skills/resolve-audit/` and writes editor-native versions to each selected editor's skills directory. Editors that share the same directory (e.g., Cursor, Codex, Gemini CLI, GitHub Copilot, Amp, and OpenCode all use `.agents/skills/`) are deduplicated automatically.
+The command reads the skill source bundled with the kural package and writes editor-native versions to each selected editor's skills directory. Editors that share the same directory (e.g., Cursor, Codex, Gemini CLI, GitHub Copilot, Amp, and OpenCode all use `.agents/skills/`) are deduplicated automatically.
 
 ## What the skill teaches
 
-The **resolve-audit** skill gives your AI assistant the full context it needs to work through audit findings:
+The **kural-audit** skill gives your AI assistant the full context it needs to work through audit findings:
 
 - **The four-phase pipeline** — fix incomplete docs first, then documentation quality, then structural issues, and only suppress with `@kuralResidual` as a last resort
 - **Per-audit resolution guidance** — what each of the 15 audits detects and how to fix it
@@ -67,18 +67,13 @@ The **resolve-audit** skill gives your AI assistant the full context it needs to
 In Claude Code, the skill is invoked as a slash command:
 
 ```
-/resolve-audit
-/resolve-audit outliers
-/resolve-audit src/analysis
+/kural-audit
+/kural-audit outliers
+/kural-audit src/analysis
 ```
 
 For other editors, the skill content is loaded as context when your assistant detects audit-related work.
 
 ## Keeping skills in sync
 
-Skill source lives in `.claude/skills/resolve-audit/`. If you update the source files, re-run `kural skill` to propagate changes to all editor targets.
-
-<Callout type="info">
-  Add editor-specific skill directories to `.gitignore` if you don't want them committed. The
-  canonical source is always `.claude/skills/resolve-audit/`.
-</Callout>
+Skill source is bundled with the kural package. When a new version of kural ships updated skills, re-run `kural skill` to propagate changes to your editor targets.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -94,7 +94,7 @@ Add terms when your codebase uses acronyms or domain-specific names that the emb
 }
 ```
 
-Sensitivity is the **single tuning knob** for all 14 audits. Every audit measures something different — sibling similarity, dominance gaps, axis scores, dendrogram merge distances — but every measurement ends at the same decision boundary: normal or abnormal. Sensitivity controls where that boundary falls.
+Sensitivity is the **single tuning knob** for all 15 audits. Every audit measures something different — sibling similarity, dominance gaps, axis scores, dendrogram merge distances — but every measurement ends at the same decision boundary: normal or abnormal. Sensitivity controls where that boundary falls.
 
 ### Why one knob is enough
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -324,7 +324,7 @@ See [Configuration](/docs/configuration) for detailed guidance on tuning these s
 
 ## Equip your AI code editor
 
-If you use an AI coding agent, give it structural awareness with the built-in resolve-audit skill:
+If you use an AI coding agent, give it structural awareness with the built-in kural-audit skill:
 
 ```bash
 kural skill

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -255,7 +255,7 @@ kural score -c <snapshot-id>
 kural audit
 ```
 
-Kural runs 14 statistical audits that surface specific, actionable structural issues -- outliers, duplicates, containment problems, and more.
+Kural runs 15 statistical audits that surface specific, actionable structural issues -- outliers, duplicates, containment problems, and more.
 
 ```bash
 # Filter by audit category
@@ -322,6 +322,18 @@ Create a `kural.config.json` in your project root to persist settings:
 
 See [Configuration](/docs/configuration) for detailed guidance on tuning these settings after your first results.
 
+## Equip your AI code editor
+
+If you use an AI coding agent, give it structural awareness with the built-in resolve-audit skill:
+
+```bash
+kural skill
+```
+
+This interactive command lets you pick your editor(s) and writes skill files that teach your assistant the four-phase audit resolution pipeline, description principles, and kural params. Supports 18 editors including Claude Code, Cursor, Windsurf, GitHub Copilot, and more.
+
+See [AI Code Editors](/docs/ai-editors) for the full list and details.
+
 ## Typical workflow
 
 <Steps>
@@ -330,6 +342,6 @@ See [Configuration](/docs/configuration) for detailed guidance on tuning these s
   <Step>**Generate** a snapshot: `kural snapshot generate src`</Step>
   <Step>**Score** the overall structure: `kural score`</Step>
   <Step>**Audit** for specific issues: `kural audit`</Step>
-  <Step>**Fix** the flagged issues, then regenerate to verify improvement</Step>
+  <Step>**Fix** the flagged issues — or run `kural skill` to equip your AI agent to fix them for you</Step>
   <Step>**Compare** before and after: `kural score -c <old-snapshot-id>`</Step>
 </Steps>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -40,6 +40,11 @@ How well we embed, score, audit, and place is what gives meaning to Kural.
     description="Domain keywords, dictionary, sensitivity — the settings that shape embedding and audit behavior after setup."
   />
   <Card
+    title="AI Code Editors"
+    href="/docs/ai-editors"
+    description="A must-have for agentic coding. Give your AI assistant structural awareness so it writes code in the right place. Supports 18 editors."
+  />
+  <Card
     title="Architecture"
     href="/docs/architecture"
     description="System overview: the pipeline, tiers, data model, and sync design."
@@ -72,7 +77,7 @@ How well we embed, score, audit, and place is what gives meaning to Kural.
   <Card
     title="Audits"
     href="/docs/pillars/audits"
-    description="14 statistical checks surface specific, actionable issues. Score and Audit cross-validate — fixing audit findings should improve scores."
+    description="15 statistical checks surface specific, actionable issues. Score and Audit cross-validate — fixing audit findings should improve scores."
   />
 </Cards>
 

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -1,8 +1,11 @@
 {
   "pages": [
     "index",
+    "---Guides---",
     "getting-started",
     "configuration",
+    "ai-editors",
+    "---Concepts---",
     "architecture",
     "foundation",
     "pillars",

--- a/docs/pillars/audits.mdx
+++ b/docs/pillars/audits.mdx
@@ -1,6 +1,6 @@
 ---
 title: Audits
-description: 14 statistical checks that surface specific structural issues
+description: 15 statistical checks that surface specific structural issues
 icon: SearchCheck
 ---
 
@@ -44,7 +44,7 @@ The `sensitivity` parameter (default 2.0) controls how many deviations from cent
 
 ---
 
-## 2. The 14 Audits
+## 2. The 15 Audits
 
 ### Bloating & Size
 
@@ -83,6 +83,8 @@ The `sensitivity` parameter (default 2.0) controls how many deviations from cent
 **incoherent-utils** — Same logic for util containers, scored within their own population.
 
 **identity-language** — Detects directories whose KURAL.md description leans toward "is" (static identity) instead of "does" (dynamic purpose). Measured against the is-does axis — 60 multilingual anchor sentences from `src/config/axis-anchors.ts`. Flags directories whose axis score falls below a robust lower fence.
+
+**weak-identity** — Detects containers where more than half the children fit a sibling module better than their own parent. Uses the drift ratio — the fraction of children whose uncle fit exceeds parent fit — and flags containers where this ratio is a Z-score upper outlier. Reports the strongest competing uncle and the parent-vs-uncle fit comparison. Requires at least 4 eligible children for the statistical test.
 
 **incomplete-docs** — Detects units missing required documentation. Functions need description, `@param`, `@returns`, and `@kuralPure` or `@kuralCauses`. Types need description. Files need file-level JSDoc. Directories need KURAL.md with a description.
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.41",
+    "@clack/prompts": "^1.2.0",
     "@poppinss/cliui": "^6.7.0",
     "@saehrimnir/druidjs": "^0.8.0",
     "@tanstack/db": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "kural": "./dist/cli.mjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "type": "module",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.41
         version: 3.0.48(zod@4.3.6)
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@poppinss/cliui':
         specifier: ^6.7.0
         version: 6.8.0
@@ -263,6 +266,12 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
+
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -2672,6 +2681,15 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -3807,6 +3825,9 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
@@ -4429,6 +4450,18 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@clack/core@1.2.0':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.2.0':
+    dependencies:
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
 
   '@colors/colors@1.5.0':
     optional: true
@@ -6417,6 +6450,16 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -8063,6 +8106,8 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
 
   slice-ansi@8.0.0:
     dependencies:

--- a/skills/kural-audit/SKILL.md
+++ b/skills/kural-audit/SKILL.md
@@ -18,9 +18,18 @@ Help the user study and resolve kural audit findings. Kural detects structural i
 
 ### Workflow
 
-#### 1. Run the Audit
+#### 1. Establish Baseline and Run the Audit
 
-Run the audit with JSON output to get structured findings:
+First, check the current score and pin it as a baseline before making any changes:
+
+```
+node dist/cli.mjs score
+node dist/cli.mjs snapshot pin <snapshot-id> <milestone-name>
+```
+
+Pin at meaningful milestones — release versions (`0.1.0`), before major refactors (`pre-refactor`), or before audit resolution sessions (`pre-audit-fix`). This creates a named checkpoint to compare against throughout the fix cycle.
+
+Then run the audit with JSON output to get structured findings:
 
 ```
 node dist/cli.mjs audit --json --expand
@@ -60,7 +69,7 @@ Always first. Descriptions carry 50% weight in the identity vector. Missing docs
 - Add missing file-level JSDoc
 - Add missing KURAL.md descriptions for directories
 
-After fixing: re-snapshot, re-audit. Proceed to Phase 2 only with the new findings.
+After fixing: re-snapshot, compare scores (`-c <baseline>`), then re-audit. Proceed to Phase 2 only if scores held or improved and with the new findings.
 
 **Phase 2: Fix documentation quality**
 Descriptions exist now, but may use wrong voice, borrow sibling vocabulary, or mismatch content. Fixing these is cheaper than structural changes and still cascades through the embedding space.
@@ -69,7 +78,7 @@ Descriptions exist now, but may use wrong voice, borrow sibling vocabulary, or m
 - `vocabulary-bleed` — Rewrite KURAL.md using vocabulary exclusive to this module's domain. Never borrow sibling or cousin vocabulary. Use `@kuralBorrows` only if cross-module vocabulary is intentional
 - `incoherent` / `incoherent-utils` — Rename the unit or rewrite its description to match actual content
 
-After fixing: re-snapshot, re-audit. Proceed to Phase 3 only with the new findings.
+After fixing: re-snapshot, compare scores (`-c <baseline>`), then re-audit. Proceed to Phase 3 only if scores held or improved and with the new findings.
 
 **Phase 3: Fix structural issues**
 Only now can you trust what the audits report. Persistent findings reflect genuine structural problems, not documentation gaps.
@@ -83,7 +92,7 @@ Only now can you trust what the audits report. Persistent findings reflect genui
 - `focal-drift` — Move `@kuralBound outward` to the actual dominant child, or refactor to restore the original focal
 - `weak-identity` — Restructure directory children or rewrite KURAL.md to establish clearer ownership
 
-After fixing: re-snapshot, re-audit. Proceed to Phase 4 only with the new findings.
+After fixing: re-snapshot, compare scores (`-c <baseline>`), then re-audit. Proceed to Phase 4 only if scores held or improved and with the new findings.
 
 **Phase 4: Suppress with @kuralResidual**
 Last resort. Suppression acknowledges a finding without resolving the underlying issue. Only valid after reading the code and confirming the finding is architecturally intentional — a deliberate design choice that should not change.
@@ -92,6 +101,40 @@ Last resort. Suppression acknowledges a finding without resolving the underlying
 - Use the `hash` field from the finding — ties suppression to current code, breaks when code changes
 
 See [reference.md](reference.md) for detailed per-audit resolution guidance.
+
+### Scoring — The Ground Truth
+
+Scores are the ultimate measure of structural quality. Audits are named paths to improve scores — each finding identifies a pattern that, when fixed, should push the score higher. Always validate fixes with scores.
+
+**Score dimensions (each -1…1):**
+
+- **Self (fit)** — how well a node belongs under its parent
+- **Children** — how coherent a container's direct children are
+- **Subtree** — recursive health of everything below
+- **Overall** — harmonic mean of Self and Subtree
+
+**The feedback loop:**
+
+1. **Baseline** — check current score before fixing: `node dist/cli.mjs score`
+2. **Fix** — apply the four-phase pipeline
+3. **Re-snapshot** — `node dist/cli.mjs snapshot generate <path>`
+4. **Compare** — `node dist/cli.mjs score -c <baseline-id-or-pin>` — did the score go up?
+
+If the score improves, the fix helped. If it drops, the fix introduced a new problem — check what new audit finding appeared. Chain fixes until scores improve and audits clear.
+
+**Pinned snapshots as baselines:**
+Pin a snapshot to create a named baseline: `node dist/cli.mjs snapshot pin <id> <name>`. Then compare against it by name: `node dist/cli.mjs score -c <name>`. Each release or milestone should pin a baseline.
+
+**Score commands:**
+
+- `node dist/cli.mjs score` — overall score
+- `node dist/cli.mjs score -e` — detailed breakdown table (default 20 rows)
+- `node dist/cli.mjs score -e -l 0` — show all rows
+- `node dist/cli.mjs score -p <path>` — filter to a specific subtree
+- `node dist/cli.mjs score -c <id-or-pin>` — compare against a previous snapshot with deltas
+- `node dist/cli.mjs score -e -p <path> -c <id-or-pin>` — detailed subtree comparison
+
+**Reading deltas:** After comparison, each score shows a delta (e.g., `0.92 ▸ +0.03`). Positive deltas mean improvement. Negative deltas mean regression — investigate what changed.
 
 ### Description Principles
 
@@ -149,8 +192,12 @@ The consultant's desk. Parses directory targets and display flags...
 
 2. **Follow the four phases in order.** Do not jump to structural changes before fixing docs. Do not suppress before attempting structural fixes.
 
-3. **Re-snapshot and re-audit between phases.** Earlier fixes change embeddings. Findings that persist through doc fixes are real; findings that vanish were false positives from incomplete information.
+3. **Re-snapshot, compare scores, and re-audit between phases.** Earlier fixes change embeddings. Compare scores against the pinned baseline (`-c <pin-name>`) to confirm improvement. Findings that persist through doc fixes are real; findings that vanish were false positives from incomplete information.
 
-4. **Include the hash when suppressing.** Format: `@kuralResidual <audit-name> [<hash>]` — take the hash from the finding's `hash` field.
+4. **Scores are the ground truth, audits are the roadmap.** A fix that clears an audit finding but drops the score introduced a new problem. A fix that improves the score is correct even if new audit findings appear — chain the fixes.
 
-5. **Run `vp check` after code changes** to validate formatting, linting, and types.
+5. **Include the hash when suppressing.** Format: `@kuralResidual <audit-name> [<hash>]` — take the hash from the finding's `hash` field.
+
+6. **Unpin temporary baselines when done.** Pinned snapshots are never auto-evicted. After a resolution session, unpin working baselines (`node dist/cli.mjs snapshot unpin <name>`) to avoid accumulating stale snapshots. Keep only release milestones pinned.
+
+7. **Run `vp check` after code changes** to validate formatting, linting, and types.

--- a/skills/kural-audit/SKILL.md
+++ b/skills/kural-audit/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: kural-audit
+description: Study kural audit findings and resolve structural issues. Use when the user wants to understand, investigate, or fix findings from kural audit — outliers, duplicates, misplaced code, vocabulary bleed, bloat, incomplete docs, containment, incoherence, or any other structural diagnostic.
+argument-hint: [audit-name or path]
+---
+
+## Resolve Audit
+
+Help the user study and resolve kural audit findings. Kural detects structural issues in TypeScript codebases — misplaced code, duplicates, poor naming, vocabulary bleed, missing docs, and more.
+
+### Arguments
+
+`$ARGUMENTS` is an optional filter:
+
+- **Audit name** (e.g., `outliers`, `misplaced`, `vocabulary-bleed`) — focus on that audit type
+- **Path** (e.g., `src/analysis`) — focus on findings affecting that subtree
+- **Empty** — run the full audit and summarize everything
+
+### Workflow
+
+#### 1. Run the Audit
+
+Run the audit with JSON output to get structured findings:
+
+```
+node dist/cli.mjs audit --json --expand
+```
+
+If `$ARGUMENTS` matches an audit name, add `--filter $ARGUMENTS`.
+
+If the audit fails with no snapshot, tell the user to generate one first:
+
+```
+node dist/cli.mjs snapshot generate <path>
+```
+
+#### 2. Study the Findings
+
+For **each** finding:
+
+1. **Read the flagged code** — open the file at the flagged unit's location
+2. **Read the surrounding context** — parent module, siblings, any KURAL.md in the directory
+3. **Assess severity** — is this a real structural problem, a documentation gap, or an intentional design choice?
+
+Present a summary grouped by audit type. For each finding, include:
+
+- The unit name and location
+- What the audit detected (in plain language, not just metric numbers)
+- Your assessment: **real issue**, **documentation gap**, **likely intentional**, or **needs investigation**
+
+#### 3. Resolve — The Four Phases
+
+Audit resolution follows a strict sequential pipeline. Each phase requires a re-snapshot and re-audit before proceeding to the next, because earlier fixes change embeddings and can resolve downstream findings.
+
+**Phase 1: Fix incomplete docs**
+Always first. Descriptions carry 50% weight in the identity vector. Missing docs produce incomplete embeddings, which cause false positives across every other audit. Many outlier, misplaced, merge-candidate, and incoherent findings will vanish once embeddings are computed from complete information.
+
+- Add missing JSDoc tags: description, `@param` for each parameter, `@returns` (non-void), `@kuralPure` or `@kuralCauses`
+- Add missing type descriptions
+- Add missing file-level JSDoc
+- Add missing KURAL.md descriptions for directories
+
+After fixing: re-snapshot, re-audit. Proceed to Phase 2 only with the new findings.
+
+**Phase 2: Fix documentation quality**
+Descriptions exist now, but may use wrong voice, borrow sibling vocabulary, or mismatch content. Fixing these is cheaper than structural changes and still cascades through the embedding space.
+
+- `identity-language` — Rewrite KURAL.md with active "does" verbs instead of static "is" descriptions
+- `vocabulary-bleed` — Rewrite KURAL.md using vocabulary exclusive to this module's domain. Never borrow sibling or cousin vocabulary. Use `@kuralBorrows` only if cross-module vocabulary is intentional
+- `incoherent` / `incoherent-utils` — Rename the unit or rewrite its description to match actual content
+
+After fixing: re-snapshot, re-audit. Proceed to Phase 3 only with the new findings.
+
+**Phase 3: Fix structural issues**
+Only now can you trust what the audits report. Persistent findings reflect genuine structural problems, not documentation gaps.
+
+- `outliers` — Move to a better-fitting parent, or extract to utils with `@kuralUtil`
+- `misplaced` — Move to the uncle directory that's a better fit
+- `merge-candidates` — Merge near-duplicates, or differentiate descriptions if they serve different purposes
+- `duplicates` / `util-duplicates` — Consolidate into one location
+- `bloated-directories` / `bloated-files` — Split along the cluster boundaries shown in the finding
+- `containments` — Flatten the wrapper, or add `@kuralBound outward` if dominance is intentional
+- `focal-drift` — Move `@kuralBound outward` to the actual dominant child, or refactor to restore the original focal
+- `weak-identity` — Restructure directory children or rewrite KURAL.md to establish clearer ownership
+
+After fixing: re-snapshot, re-audit. Proceed to Phase 4 only with the new findings.
+
+**Phase 4: Suppress with @kuralResidual**
+Last resort. Suppression acknowledges a finding without resolving the underlying issue. Only valid after reading the code and confirming the finding is architecturally intentional — a deliberate design choice that should not change.
+
+- Add `@kuralResidual <audit-name> [<hash>]` to the unit's JSDoc or KURAL.md
+- Use the `hash` field from the finding — ties suppression to current code, breaks when code changes
+
+See [reference.md](reference.md) for detailed per-audit resolution guidance.
+
+### Description Principles
+
+Every unit's description — directory KURAL.md, file-level JSDoc, function JSDoc, and type JSDoc — is embedded and carries **50% weight** in the identity vector. Description quality directly affects scoring accuracy. The same principles apply at every level.
+
+1. **Describe what only THIS unit does, in its own vocabulary.** Use exclusivity language: "It is the only module that...", "Nothing else in the system...". This creates semantic separation between siblings.
+2. **Never borrow sibling or cousin module vocabulary.** Naming other modules' concepts (e.g., "embedding providers" in config, "parse-embed-store pipeline" in a command) pulls the description toward those modules in embedding space. Use abstract terms instead: "provider selection", "the engine". The vocabulary bleed audit catches this automatically.
+3. **Anchor identity with a metaphor.** Lead with a one-word role ("The brain", "The memory", "The toolbox") that captures the unit's irreplaceable character in the system. Most impactful for directories and files; optional for individual functions and types.
+4. **Describe the role in the system, not a generic job.** "Persists and retrieves all application state in a local database" is better than "SQLite database schema and operations" — the former says what makes it unique here, the latter describes any database module anywhere. For functions: "Persists computed health metrics so downstream commands can query scores without re-running the pipeline" is better than "Writes score cards to the snapshot."
+5. **For folder-level descriptions, combine children's identities.** A parent folder's KURAL.md should describe the shared boundary its children own, not repeat their individual descriptions. Example: "The reader and translator — turns source files into numerical vectors" combines parse and embed's roles.
+
+### Kural Params
+
+Params are JSDoc annotations that declare structural realities the vector space can't capture. They directly affect which audits fire and how scores compute.
+
+| Param                         | Role in scoring                                              |
+| :---------------------------- | :----------------------------------------------------------- |
+| `@kuralHelper`                | Participates in scoring, excluded from audits                |
+| `@kuralUtil`                  | Excluded from domain scoring, scored in own sandbox          |
+| `@kuralPatterns`              | Deduplicated to centroid representative                      |
+| `@kuralCompanion`             | Deduplicated to centroid representative                      |
+| `@kuralResidual`              | No role in scoring, audit suppression only                   |
+| `@kuralBound inward/outward`  | Adjusted scoring + selective audit suppression               |
+| `@kuralBorrows target "role"` | Instruction prefix for name/desc embedding + audit exclusion |
+| `@kuralPure` / `@kuralCauses` | Influences what gets embedded, not how scores compute        |
+
+#### `@kuralBorrows` — Cross-Layer Vocabulary Borrowing
+
+A KURAL.md directive for directories that intentionally share vocabulary with a non-sibling module (e.g., a shell command that presents an analysis engine's output).
+
+**Format:**
+
+```markdown
+The consultant's desk. Parses directory targets and display flags...
+@kuralBorrows analysis/advise "terminal surface that formats and renders engine output as diagrams and tables"
+```
+
+- **Target path** (optional): relative path like `analysis/advise` — excludes that module from the vocabulary bleed audit's cross-pull comparison.
+- **Quoted role** (required): natural-language description of the borrower's role — used as an instruction prefix when embedding the directory's name and description.
+
+**How it works:**
+
+1. **Embedding pipeline**: The role text is prepended to both the name and description before embedding. Instead of embedding `"advise"`, the system embeds `"terminal surface that formats and renders engine output as diagrams and tables: advise"`. This contextualizes shared vocabulary through the attention mechanism — "advise" in a display context encodes differently from "advise" in a computation context.
+2. **Vocabulary bleed audit**: If a target path is declared, the audit skips that module when computing cross-pulls, since the overlap is intentional.
+
+**Principles for writing the role text:**
+
+1. **Describe the borrower's role, not the target's domain.** "terminal surface that formats and renders engine output as diagrams and tables" describes what the shell module does. "presentation layer for the directory advice engine" names the analysis module's domain, which pulls embeddings toward it.
+2. **Describe the role in this system, not a generic job.** "formats and renders engine output as diagrams and tables" is specific to this module. "renders output" is generic and provides weak separation.
+3. **Never use the target module's vocabulary.** The same rule as descriptions — borrowed terms in the role text increase cross-pull instead of reducing it.
+
+### Rules
+
+1. **Always read the code before proposing fixes.** Never suggest changes based solely on finding metadata.
+
+2. **Follow the four phases in order.** Do not jump to structural changes before fixing docs. Do not suppress before attempting structural fixes.
+
+3. **Re-snapshot and re-audit between phases.** Earlier fixes change embeddings. Findings that persist through doc fixes are real; findings that vanish were false positives from incomplete information.
+
+4. **Include the hash when suppressing.** Format: `@kuralResidual <audit-name> [<hash>]` — take the hash from the finding's `hash` field.
+
+5. **Run `vp check` after code changes** to validate formatting, linting, and types.

--- a/skills/kural-audit/reference.md
+++ b/skills/kural-audit/reference.md
@@ -1,0 +1,243 @@
+# Audit Resolution Reference
+
+Detailed per-audit guidance for resolving kural findings.
+
+---
+
+## Bloating & Size
+
+### bloated-directories
+
+**Detects:** Directories whose children cluster into distinct semantic groups (dendrogram gap analysis). The finding includes the cluster composition.
+
+**Resolution:**
+
+1. Read the cluster composition from the finding's `clusters` field
+2. Create subdirectories matching the natural groupings
+3. Move children into their respective clusters
+4. Write KURAL.md for each new directory following the description principles
+5. Update the parent KURAL.md to describe the new boundary
+
+**Suppress when:** The breadth is the intended architecture (e.g., `src/` spanning the full lifecycle).
+
+### bloated-files
+
+**Detects:** Files whose functions/types cluster into semantic groups.
+
+**Resolution:**
+
+1. Read the clusters — ignore type-vs-function splits (those are natural, not actionable)
+2. Extract each semantic cluster into its own file
+3. Add file-level JSDoc to each new file
+4. Update imports across the codebase
+
+**Suppress when:** The file intentionally houses a cohesive set that just happens to be large.
+
+---
+
+## Outliers & Cohesion
+
+### outliers
+
+**Detects:** Children whose mean cosine similarity to siblings is statistically low (MAD-based robust lower fence). The finding shows the unit's mean similarity vs the group mean.
+
+**Resolution options (in order of preference):**
+
+1. **Move it** — find the directory where it has higher sibling similarity
+2. **Improve its description** — if it genuinely belongs, sharpen the JSDoc/KURAL.md to explain why. A vague description produces a vague embedding
+3. **Extract to utils** — if it's a general-purpose helper, mark `@kuralUtil` and move to the utils directory
+4. **Suppress** — only if the placement is intentional and the description is already accurate
+
+**Key insight:** An outlier that is also flagged as misplaced is a strong signal to move it. The `misplaced` audit applies a lenient fence for known outliers.
+
+### merge-candidates
+
+**Detects:** Sibling pairs whose similarity exceeds the upper fence — near-duplicates within the same parent.
+
+**Resolution options:**
+
+1. **Merge** — combine into a single unit if they do the same thing
+2. **Differentiate** — if they serve different purposes, rewrite descriptions to create semantic separation. Use exclusivity language
+3. **Extract shared logic** — if they share a core but differ at the edges, extract the common part
+4. **Mark as pattern** — if the repetition is intentional (e.g., handler functions), add `@kuralPatterns <group>` to both
+
+**Caller-callee pairs are already filtered out** — if a merge-candidate appears, the pair isn't a simple caller-callee relationship.
+
+---
+
+## Containment & Hierarchy
+
+### containments
+
+**Detects:** Parents where one child's dominance gap is an upper outlier — the parent is essentially a wrapper around a single child.
+
+**Resolution options:**
+
+1. **Flatten** — move the dominant child up one level, eliminating the wrapper
+2. **Add siblings** — if the parent should exist, add more children to justify it
+3. **Mark outward-bound** — if the dominant child IS the purpose of the parent, add `@kuralBound outward` to the child. This suppresses the containment finding on the parent
+
+**The finding shows:** `dominantName`, `dominantSim`, `secondSim` — use the gap between these to judge severity.
+
+### misplaced
+
+**Detects:** Nodes that fit an uncle (sibling directory) better than their own parent, by a statistically significant delta.
+
+**Resolution options:**
+
+1. **Move it** — relocate to the uncle directory that's a better fit
+2. **Improve parent description** — if the parent's KURAL.md doesn't capture this child's role, rewriting it may reduce the delta
+3. **Improve child description** — sharpen the unit's JSDoc to anchor it to the parent's domain
+4. **Suppress** — when the placement is intentional despite semantic distance (e.g., a command that must live near other commands even though it's close to the engine)
+
+**The finding shows:** `uncleFit` vs parent `value` — the delta tells you how much better the uncle fits. Also shows which uncle via `pairKey`.
+
+---
+
+## Cross-Module Duplicates
+
+### duplicates
+
+**Detects:** Semantically identical units separated by module boundaries. Three scan types: cross-file leaves, cross-directory files, and cross-population (util vs domain).
+
+**Resolution options:**
+
+1. **Consolidate** — move one to a shared location and import from there
+2. **Differentiate** — if they look similar but serve different domains, rewrite descriptions with exclusivity language
+3. **Mark as companions** — if structural coupling is intentional, add `@kuralCompanion <group>` to both
+4. **Mark as pattern** — if they follow the same template, add `@kuralPatterns <group>`
+
+**Already filtered out:** @kuralPatterns groups, caller-callee pairs, @kuralCompanion pairs.
+
+### util-duplicates
+
+**Detects:** Util functions/types in separate files exceeding the merge fence.
+
+**Resolution:** Same as `duplicates`, but focused on the util layer. Consider whether two util functions doing similar things should be one function with a parameter.
+
+---
+
+## Vocabulary & Identity
+
+### focal-drift
+
+**Detects:** `@kuralBound outward` nodes that are no longer the most similar child to their parent — another child has overtaken them.
+
+**Resolution options:**
+
+1. **Move the tag** — if the new dominant child IS the file's purpose now, move `@kuralBound outward` to it
+2. **Refactor** — if the original focal should still be dominant, trim the overtaking child or move it elsewhere
+3. **Split the file** — if both deserve to be focal, they belong in separate files
+
+**The finding shows:** `actualTopName` (the overtaker), `topSim`, `selfSim`.
+
+### vocabulary-bleed
+
+**Detects:** Directories whose KURAL.md description is closer (in embedding space) to a non-sibling module than to their weakest sibling.
+
+**Resolution:**
+
+1. **Rewrite KURAL.md** — this is almost always the fix. The description borrows vocabulary from another module's domain
+2. **Identify the borrowed terms** — the finding shows the top 3 non-sibling pulls. Read those modules' KURAL.md to see what vocabulary is being shared
+3. **Use exclusive vocabulary** — describe what THIS directory does without naming other modules' concepts. Use abstract terms instead: "the engine" instead of "the scoring pipeline"
+4. **Add @kuralBorrows** — if cross-module vocabulary sharing is intentional (e.g., a shell command presenting an engine's output), declare it:
+   ```
+   @kuralBorrows target/path "role description using this module's vocabulary, not the target's"
+   ```
+
+**The finding shows:** `minSiblingSim` (weakest sibling) and `crossPulls` (array of `{path, sim}` for top 3 non-sibling pulls).
+
+### identity-language
+
+**Detects:** KURAL.md descriptions leaning toward "is" (static identity) instead of "does" (dynamic purpose). Measured against the is-does axis.
+
+**Resolution:**
+
+1. **Rewrite with active verbs** — change "The configuration module" to "Loads, validates, and merges configuration from disk and CLI overrides"
+2. **Lead with what it does, not what it is** — "Persists and retrieves all application state" beats "The database layer"
+3. **Keep the metaphor** — the one-word metaphor ("The brain", "The memory") is fine as an anchor, but the rest of the description should be active
+
+---
+
+## Documentation & Coherence
+
+### incoherent / incoherent-utils
+
+**Detects:** Containers whose name/description diverges from actual content. The identity embedding and content embedding point in different directions.
+
+**Resolution options:**
+
+1. **Rename** — if the name is misleading, rename the file/directory to match what it actually contains
+2. **Rewrite description** — if the name is fine but the description is stale or generic
+3. **Restructure** — if the content has drifted from the original purpose, move mismatched children out
+
+**The finding shows:** identity-content similarity score. Lower = worse mismatch.
+
+### weak-identity
+
+**Detects:** Containers where >50% of children fit a sibling module better than their own parent.
+
+**Resolution options:**
+
+1. **Restructure** — move drifting children to their better-fitting uncle
+2. **Rewrite KURAL.md** — if the directory's description doesn't capture what most children actually do
+3. **Split** — if the directory has genuinely diverged into two concerns, split it
+
+**The finding shows:** `driftCount`/`childCount` (how many drift), `pairKey` (strongest competing uncle), parent fit vs uncle fit.
+
+### incomplete-docs
+
+**Detects:** Units missing required documentation. Deterministic checklist, no statistical fence.
+
+**Required by kind:**
+
+- **Functions:** description, `@param` for each parameter, `@returns` (non-void), `@kuralPure` or `@kuralCauses`
+- **Types:** description
+- **Files:** file-level JSDoc with description
+- **Directories:** KURAL.md with description content
+
+**Resolution:** Add the missing items. The finding's `missing` array lists exactly what's needed.
+
+**For @kuralPure vs @kuralCauses:**
+
+- `@kuralPure` — function has no side effects (pure computation)
+- `@kuralCauses <description>` — describes what the function does beyond its type signature (e.g., "writes score data to the snapshot database")
+
+---
+
+## Suppression Reference
+
+### Format
+
+**In JSDoc (functions, types, files):**
+
+```typescript
+/**
+ * Description of the unit.
+ * @kuralResidual <audit-name> [<hash>]
+ */
+```
+
+**In KURAL.md (directories):**
+
+```markdown
+The metaphor. Description of the directory's purpose.
+@kuralResidual <audit-name> [<hash>]
+```
+
+### Hash behavior
+
+- **With hash** `[abc123]` — suppression is tied to current code. Breaks when code changes, forcing re-evaluation
+- **Without hash** — permanent suppression. Use sparingly
+
+### When to suppress
+
+- The finding is architecturally intentional and documented
+- Moving the code would break a more important organizational principle
+- The module intentionally borrows vocabulary (use `@kuralBorrows` instead for vocabulary-bleed)
+
+### When NOT to suppress
+
+- To avoid writing documentation (fix incomplete-docs instead)
+- To avoid restructuring (fix the structure)
+- When you haven't read the code to confirm the finding is intentional

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { existsSync } from "node:fs";
 import { loadEnvFile } from "node:process";
 import place from "./shell/commands/place/command.ts";
 import score from "./shell/commands/score/command.ts";
+import skill from "./shell/commands/skill/command.ts";
 import snapshot from "./shell/commands/snapshot/command.ts";
 
 const ARGV_START = 2;
@@ -31,5 +32,5 @@ if (existsSync(".env")) {
 await cli(process.argv.slice(ARGV_START), snapshot, {
   name: "kural",
   version: "0.0.0",
-  subCommands: { advise, audit, place, score },
+  subCommands: { advise, audit, place, score, skill },
 });

--- a/src/shell/commands/skill/KURAL.md
+++ b/src/shell/commands/skill/KURAL.md
@@ -1,0 +1,1 @@
+The distributor. Reads bundled skill definitions and writes editor-native versions to the user's project. It is the only command that crosses the boundary between kural's internal knowledge and external AI code editors — no other module knows how editors consume instruction files or where they store them.

--- a/src/shell/commands/skill/command.ts
+++ b/src/shell/commands/skill/command.ts
@@ -6,7 +6,7 @@
  * its interactive flow.
  */
 
-import { confirm, intro, isCancel, multiselect, outro } from "@clack/prompts";
+import { confirm, intro, isCancel, log, multiselect, outro } from "@clack/prompts";
 import { define } from "gunshi";
 import { editors } from "./editors.ts";
 import { writeSkills } from "./pipeline.ts";
@@ -36,7 +36,7 @@ async function handleAddSkill(): Promise<void> {
   const chosen = editors.filter((e) => selected.includes(e.value));
 
   const proceed = await confirm({
-    message: `Write resolve-audit skill to ${String(chosen.length)} editor(s)?`,
+    message: `Write kural-audit skill to ${String(chosen.length)} editor(s)?`,
   });
 
   if (isCancel(proceed) || !proceed) {
@@ -49,16 +49,12 @@ async function handleAddSkill(): Promise<void> {
   const ok = results.filter((r) => r.ok);
   const failed = results.filter((r) => !r.ok);
 
-  if (ok.length > NONE) {
-    for (const r of ok) {
-      console.log(`  \u001B[32m✓\u001B[0m ${r.editor} → ${r.path}`);
-    }
+  for (const r of ok) {
+    log.success(`${r.editor} → ${r.path}`);
   }
 
-  if (failed.length > NONE) {
-    for (const r of failed) {
-      console.log(`  \u001B[31m✗\u001B[0m ${r.editor} → ${r.error}`);
-    }
+  for (const r of failed) {
+    log.error(`${r.editor} → ${r.error}`);
   }
 
   outro(

--- a/src/shell/commands/skill/command.ts
+++ b/src/shell/commands/skill/command.ts
@@ -15,6 +15,7 @@ const NONE = 0;
 
 /**
  * Runs the interactive skill flow.
+ * @returns a promise that resolves when skill files have been written
  * @kuralCauses prompts user for editor selection and writes skill files to disk
  */
 async function handleAddSkill(): Promise<void> {

--- a/src/shell/commands/skill/command.ts
+++ b/src/shell/commands/skill/command.ts
@@ -1,0 +1,78 @@
+/**
+ * The interface. Defines the CLI argument schema and wires user input
+ * into the skill writer pipeline via Clack prompts. It is the only
+ * module that speaks the Gunshi command protocol for the skill
+ * command — no other module defines its arguments or orchestrates
+ * its interactive flow.
+ */
+
+import { confirm, intro, isCancel, multiselect, outro } from "@clack/prompts";
+import { define } from "gunshi";
+import { editors } from "./editors.ts";
+import { writeSkills } from "./pipeline.ts";
+
+const NONE = 0;
+
+/**
+ * Runs the interactive skill flow.
+ * @kuralCauses prompts user for editor selection and writes skill files to disk
+ */
+async function handleAddSkill(): Promise<void> {
+  const root = process.cwd();
+
+  intro("Add kural skill to your editor");
+
+  const selected = await multiselect({
+    message: "Which editors do you use?",
+    options: editors.map((e) => ({ value: e.value, label: e.label })),
+    required: true,
+  });
+
+  if (isCancel(selected)) {
+    outro("Cancelled.");
+    return;
+  }
+
+  const chosen = editors.filter((e) => selected.includes(e.value));
+
+  const proceed = await confirm({
+    message: `Write resolve-audit skill to ${String(chosen.length)} editor(s)?`,
+  });
+
+  if (isCancel(proceed) || !proceed) {
+    outro("Cancelled.");
+    return;
+  }
+
+  const results = writeSkills(root, chosen);
+
+  const ok = results.filter((r) => r.ok);
+  const failed = results.filter((r) => !r.ok);
+
+  if (ok.length > NONE) {
+    for (const r of ok) {
+      console.log(`  \u001B[32m✓\u001B[0m ${r.editor} → ${r.path}`);
+    }
+  }
+
+  if (failed.length > NONE) {
+    for (const r of failed) {
+      console.log(`  \u001B[31m✗\u001B[0m ${r.editor} → ${r.error}`);
+    }
+  }
+
+  outro(
+    failed.length === NONE
+      ? "Done! Skill files written."
+      : `Done with ${String(failed.length)} error(s).`,
+  );
+}
+
+export default define({
+  name: "skill",
+  description: "Add kural skills to your AI code editor",
+  args: {},
+  run: async () => {
+    await handleAddSkill();
+  },
+});

--- a/src/shell/commands/skill/editors.ts
+++ b/src/shell/commands/skill/editors.ts
@@ -1,0 +1,106 @@
+/**
+ * The catalog. Defines every supported editor's skill file layout —
+ * path patterns, format adapters, and metadata conventions. It is
+ * the only module that knows where each editor stores its instruction
+ * files and how to transform shared skill content into editor-native
+ * format.
+ * @kuralBound outward
+ */
+
+const FIRST = 0;
+const SKILL_DIR = "resolve-audit";
+const SKILL_FILE = "SKILL.md";
+
+/** @kuralPure */
+function stripYamlFrontmatter(content: string): string {
+  const match = /^---\n[\s\S]*?\n---\n/.exec(content);
+  if (match === null) {
+    return content;
+  }
+  return content.slice(match[FIRST].length).trimStart();
+}
+
+/**
+ * A target editor that kural can write skills to.
+ */
+type Editor = {
+  /** Display label for the multiselect prompt. */
+  label: string;
+  /** Short identifier. */
+  value: string;
+  /** Relative path from project root where the skill file is written. */
+  path: string;
+  /**
+   * Transforms the SKILL.md content and reference content into the
+   * editor-native format.
+   * @param skill - raw SKILL.md content including YAML frontmatter
+   * @param reference - raw reference.md content
+   * @returns the final file content to write
+   */
+  transform: (skill: string, reference: string) => string;
+};
+
+/**
+ * Builds plain markdown by stripping frontmatter and merging both files.
+ * @param skill - raw SKILL.md content
+ * @param reference - raw reference.md content
+ * @returns plain markdown content without YAML frontmatter
+ * @kuralPure
+ */
+function buildPlainMarkdown(skill: string, reference: string): string {
+  const body = stripYamlFrontmatter(skill);
+  const ref = stripYamlFrontmatter(reference);
+  return `${body}\n\n${ref}\n`;
+}
+
+/**
+ * Creates an editor entry that writes a plain markdown SKILL.md into
+ * the editor's skills directory.
+ * @param label - display name for the prompt
+ * @param value - short identifier
+ * @param skillsDir - relative path to the editor's skills root
+ * @returns an Editor definition
+ * @kuralPure
+ */
+function skillsDirEditor(label: string, value: string, skillsDir: string): Editor {
+  return {
+    label,
+    value,
+    path: `${skillsDir}/${SKILL_DIR}/${SKILL_FILE}`,
+    transform: buildPlainMarkdown,
+  };
+}
+
+/**
+ * All supported editors and their skill file conventions.
+ * Aligned with Vite Plus editor support.
+ * @kuralPure
+ */
+const editors: Editor[] = [
+  {
+    label: "Claude Code",
+    value: "claude",
+    path: `.claude/skills/${SKILL_DIR}/${SKILL_FILE}`,
+    transform: (skill: string, _reference: string) => skill,
+  },
+  skillsDirEditor("Cursor", "cursor", ".agents/skills"),
+  skillsDirEditor("Windsurf", "windsurf", ".windsurf/skills"),
+  skillsDirEditor("Codex", "codex", ".agents/skills"),
+  skillsDirEditor("Gemini CLI", "gemini", ".agents/skills"),
+  skillsDirEditor("GitHub Copilot", "copilot", ".agents/skills"),
+  skillsDirEditor("Cline", "cline", ".cline/skills"),
+  skillsDirEditor("Amp", "amp", ".agents/skills"),
+  skillsDirEditor("Roo Code", "roo", ".roo/skills"),
+  skillsDirEditor("Kilo Code", "kilo", ".kilocode/skills"),
+  skillsDirEditor("Continue", "continue", ".continue/skills"),
+  skillsDirEditor("Goose", "goose", ".goose/skills"),
+  skillsDirEditor("OpenCode", "opencode", ".agents/skills"),
+  skillsDirEditor("Trae", "trae", ".trae/skills"),
+  skillsDirEditor("Junie", "junie", ".junie/skills"),
+  skillsDirEditor("Kiro CLI", "kiro", ".kiro/skills"),
+  skillsDirEditor("Zencoder", "zencoder", ".zencoder/skills"),
+  skillsDirEditor("Qwen Code", "qwen", ".qwen/skills"),
+];
+
+export type { Editor };
+export { editors };

--- a/src/shell/commands/skill/editors.ts
+++ b/src/shell/commands/skill/editors.ts
@@ -8,7 +8,7 @@
  */
 
 const FIRST = 0;
-const SKILL_DIR = "resolve-audit";
+const SKILL_DIR = "kural-audit";
 const SKILL_FILE = "SKILL.md";
 
 /** @kuralPure */

--- a/src/shell/commands/skill/editors.ts
+++ b/src/shell/commands/skill/editors.ts
@@ -4,14 +4,18 @@
  * the only module that knows where each editor stores its instruction
  * files and how to transform shared skill content into editor-native
  * format.
- * @kuralBound outward
  */
 
 const FIRST = 0;
 const SKILL_DIR = "kural-audit";
 const SKILL_FILE = "SKILL.md";
 
-/** @kuralPure */
+/**
+ * Removes YAML frontmatter delimited by triple dashes from markdown content.
+ * @param content - raw markdown string potentially starting with frontmatter
+ * @returns the content without the leading frontmatter block
+ * @kuralPure
+ */
 function stripYamlFrontmatter(content: string): string {
   const match = /^---\n[\s\S]*?\n---\n/.exec(content);
   if (match === null) {

--- a/src/shell/commands/skill/pipeline.ts
+++ b/src/shell/commands/skill/pipeline.ts
@@ -3,7 +3,6 @@
  * editor-specific versions to disk. It is the only module that
  * performs file I/O for the skill command — no other module
  * reads skill sources or writes editor output.
- * @kuralBound outward
  */
 
 import { dirname, resolve } from "node:path";

--- a/src/shell/commands/skill/pipeline.ts
+++ b/src/shell/commands/skill/pipeline.ts
@@ -1,0 +1,67 @@
+/**
+ * The writer. Reads the shared skill source files and writes
+ * editor-specific versions to disk. It is the only module that
+ * performs file I/O for the skill command — no other module
+ * reads skill sources or writes editor output.
+ * @kuralBound outward
+ */
+
+import { dirname, resolve } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import type { Editor } from "./editors.ts";
+
+const SKILL_SOURCE = ".claude/skills/resolve-audit/SKILL.md";
+const REFERENCE_SOURCE = ".claude/skills/resolve-audit/reference.md";
+
+/** Result of writing a single editor skill file. */
+type WriteResult = {
+  editor: string;
+  path: string;
+  ok: boolean;
+  error?: string;
+};
+
+/**
+ * Reads the shared skill sources and writes editor-specific files.
+ * @param root - absolute path to the project root
+ * @param selected - editors chosen by the user
+ * @returns an array of write results, one per editor
+ * @kuralCauses reads skill source files and writes editor-specific skill files to disk
+ */
+function writeSkills(root: string, selected: Editor[]): WriteResult[] {
+  const skillPath = resolve(root, SKILL_SOURCE);
+  const referencePath = resolve(root, REFERENCE_SOURCE);
+
+  const skill = readFileSync(skillPath, "utf-8");
+  const reference = readFileSync(referencePath, "utf-8");
+
+  const results: WriteResult[] = [];
+  const written = new Set<string>();
+
+  for (const editor of selected) {
+    if (written.has(editor.path)) {
+      results.push({ editor: editor.label, path: editor.path, ok: true });
+      continue;
+    }
+    const outPath = resolve(root, editor.path);
+    try {
+      mkdirSync(dirname(outPath), { recursive: true });
+      const content = editor.transform(skill, reference);
+      writeFileSync(outPath, content, "utf-8");
+      written.add(editor.path);
+      results.push({ editor: editor.label, path: editor.path, ok: true });
+    } catch (err) {
+      results.push({
+        editor: editor.label,
+        path: editor.path,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return results;
+}
+
+export type { WriteResult };
+export { writeSkills };

--- a/src/shell/commands/skill/pipeline.ts
+++ b/src/shell/commands/skill/pipeline.ts
@@ -9,9 +9,10 @@
 import { dirname, resolve } from "node:path";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import type { Editor } from "./editors.ts";
+import { fileURLToPath } from "node:url";
 
-const SKILL_SOURCE = ".claude/skills/resolve-audit/SKILL.md";
-const REFERENCE_SOURCE = ".claude/skills/resolve-audit/reference.md";
+const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SKILL_DIR = resolve(PKG_ROOT, "skills", "kural-audit");
 
 /** Result of writing a single editor skill file. */
 type WriteResult = {
@@ -23,17 +24,14 @@ type WriteResult = {
 
 /**
  * Reads the shared skill sources and writes editor-specific files.
- * @param root - absolute path to the project root
+ * @param root - absolute path to the user's project root
  * @param selected - editors chosen by the user
  * @returns an array of write results, one per editor
  * @kuralCauses reads skill source files and writes editor-specific skill files to disk
  */
 function writeSkills(root: string, selected: Editor[]): WriteResult[] {
-  const skillPath = resolve(root, SKILL_SOURCE);
-  const referencePath = resolve(root, REFERENCE_SOURCE);
-
-  const skill = readFileSync(skillPath, "utf-8");
-  const reference = readFileSync(referencePath, "utf-8");
+  const skill = readFileSync(resolve(SKILL_DIR, "SKILL.md"), "utf-8");
+  const reference = readFileSync(resolve(SKILL_DIR, "reference.md"), "utf-8");
 
   const results: WriteResult[] = [];
   const written = new Set<string>();

--- a/src/shell/commands/skill/pipeline.ts
+++ b/src/shell/commands/skill/pipeline.ts
@@ -6,7 +6,7 @@
  */
 
 import { dirname, resolve } from "node:path";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import type { Editor } from "./editors.ts";
 import { fileURLToPath } from "node:url";
 
@@ -22,6 +22,22 @@ type WriteResult = {
 };
 
 /**
+ * Reads a skill source file with a clear error if missing.
+ * @param name - filename within the skill directory
+ * @returns the file content as a string
+ * @kuralCauses reads a file from the skill directory bundled with the package
+ */
+function readSkillFile(name: string): string {
+  const filePath = resolve(SKILL_DIR, name);
+  if (!existsSync(filePath)) {
+    throw new Error(
+      `Skill file not found: ${filePath}. The kural package may be corrupted — try reinstalling.`,
+    );
+  }
+  return readFileSync(filePath, "utf-8");
+}
+
+/**
  * Reads the shared skill sources and writes editor-specific files.
  * @param root - absolute path to the user's project root
  * @param selected - editors chosen by the user
@@ -29,8 +45,8 @@ type WriteResult = {
  * @kuralCauses reads skill source files and writes editor-specific skill files to disk
  */
 function writeSkills(root: string, selected: Editor[]): WriteResult[] {
-  const skill = readFileSync(resolve(SKILL_DIR, "SKILL.md"), "utf-8");
-  const reference = readFileSync(resolve(SKILL_DIR, "reference.md"), "utf-8");
+  const skill = readSkillFile("SKILL.md");
+  const reference = readSkillFile("reference.md");
 
   const results: WriteResult[] = [];
   const written = new Set<string>();


### PR DESCRIPTION
## Summary

- Add `kural skill` interactive CLI command (Clack prompts) that writes the kural-audit skill to 18 AI code editors
- Ship skill source files (`skills/kural-audit/`) with the npm package, compatible with Vercel skills ecosystem (`npx skills add razyones/kural`)
- Add kural-audit skill with four-phase audit resolution pipeline, scoring feedback loop, per-audit guidance, description principles, and kural params reference
- Add `docs/ai-editors.mdx` page with supported editors, agentic coding value proposition, and skill usage
- Add homepage pill banner ("A Necessity for Agentic Coding") linking to AI editors page
- Add sidebar separators (Guides / Concepts) via docsDataPlugin separator support
- Update audit count from 14 to 15 across all docs (add weak-identity)
- Fix Steps component spacing in architecture.mdx
- Resolve all audit findings in skill command (0 findings, score 0.918)

## Test plan

- [x] `vp pack && node dist/cli.mjs skill` — interactive flow writes skill files to selected editors
- [x] `node dist/cli.mjs score -e -c 0.0.1-alpha.1` — detailed score comparison works with pin names
- [x] `node dist/cli.mjs audit --json` — 0 findings
- [x] `vp run docs:dev` — homepage banner, AI editors page, sidebar categories render correctly
- [x] `vp check && vp test` — 820 tests pass, lint clean