### PR TITLE
feat: prerender docs pages and add 404 page

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -62,9 +62,8 @@ jobs:
         env:
           BASE_PATH: ${{ steps.base.outputs.path }}
 
-      - name: Generate SPA fallback pages
+      - name: Generate SPA fallback 404
         run: |
-          cp docs-site/.output/public/_shell.html docs-site/.output/public/index.html
           cp docs-site/.output/public/_shell.html docs-site/.output/public/404.html
 
       - name: Upload build output

--- a/docs-site/src/components/not-found.tsx
+++ b/docs-site/src/components/not-found.tsx
@@ -1,0 +1,63 @@
+import { Link } from "@tanstack/react-router";
+import { BlinkingOwl } from "@/components/nav-logo";
+
+const OWL_FONT = '"IBM Plex Mono", monospace';
+const DISPLAY_FONT = '"Lexend Peta", sans-serif';
+
+export function NotFound() {
+  const base = import.meta.env.BASE_URL ?? "/";
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-6 py-20">
+      <div className="flex items-center gap-10">
+        {/* Left: Owl */}
+        <div className="text-[1.8rem] sm:text-[2.5rem]">
+          <BlinkingOwl />
+        </div>
+
+        {/* Separator */}
+        <div className="w-px self-stretch bg-fd-border" />
+
+        {/* Right: Content */}
+        <div className="flex flex-col gap-4">
+          <span
+            className="text-[4rem] sm:text-[5rem] font-semibold leading-none tracking-[-0.06em] text-fd-foreground/10"
+            style={{ fontFamily: DISPLAY_FONT }}
+          >
+            404
+          </span>
+
+          <p
+            className="text-sm tracking-wide text-fd-muted-foreground"
+            style={{ fontFamily: OWL_FONT }}
+          >
+            node not found in the tree
+          </p>
+
+          <div className="flex items-center gap-3 mt-2">
+            <Link
+              to="/"
+              className="px-5 py-2 bg-fd-primary text-fd-primary-foreground text-[11px] uppercase tracking-[0.05em] font-medium hover:opacity-90 transition-opacity"
+            >
+              Home
+            </Link>
+            <Link
+              to="/docs/$"
+              params={{ _splat: "" }}
+              className="px-5 py-2 border border-fd-border text-fd-foreground text-[11px] uppercase tracking-[0.05em] font-medium hover:border-fd-primary/40 transition-colors"
+            >
+              Read Docs
+            </Link>
+          </div>
+
+          <p
+            className="text-[10px] text-fd-muted-foreground/50 tracking-wide mt-1"
+            style={{ fontFamily: OWL_FONT }}
+          >
+            {base}??? &mdash; no score, no embedding, no placement
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs-site/src/routes/__root.tsx
+++ b/docs-site/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import { useDocsSearch } from "fumadocs-core/search/client";
 import { Loader2, Sparkles } from "lucide-react";
 import type { EmbedderStatus } from "@/lib/search";
 import { AnimatedBg } from "@/components/animated-bg";
+import { NotFound } from "@/components/not-found";
 import appCss from "@/styles/app.css?url";
 import config from "../../docs.config";
 
@@ -57,6 +58,7 @@ function StableSearchItem(props: ComponentProps<typeof SearchDialogListItem>) {
 
 export const Route = createRootRoute({
   component: RootComponent,
+  notFoundComponent: NotFound,
   head: () => ({
     meta: [
       { charSet: "utf-8" },

--- a/docs-site/vite.docs.config.ts
+++ b/docs-site/vite.docs.config.ts
@@ -272,6 +272,7 @@ export default defineConfig({
           crawlLinks: true,
         },
       },
+      pages: [{ path: "/docs" }, { path: "/llms.txt" }, { path: "/llms-full.txt" }],
     }),
     react(),
     nitro(),


### PR DESCRIPTION
## Summary
- Add `pages` array to `tanstackStart` config so `llms.txt`, `llms-full.txt`, and `/docs` are prerendered at build time — enables AI agents to fetch docs content from GitHub Pages
- Add custom 404 page with BlinkingOwl mascot, horizontal layout (owl | separator | content)
- Stop overwriting prerendered `index.html` with SPA shell in deploy workflow

## Test plan
- [x] `vp check` passes (no lint/type errors)
- [x] All tests pass (820 + 49)
- [x] Local build prerenders 18 pages including `llms.txt` and `llms-full.txt`
- [x] 404 page renders correctly on invalid routes
- [x] Verify deployed site serves `llms.txt` and `llms-full.txt` as plain text
- [x] Verify 404.html fallback works on GitHub Pages