### PR TITLE
fix: add --comment flag to code-review plugin in CI

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- The `code-review` marketplace plugin defaults to terminal-only output. Without `--comment`, the review runs in CI, costs tokens, but posts nothing visible on the PR.
- This PR adds the `--comment` flag so the plugin posts its findings as a PR comment.

## Context
The plugin README documents this behavior: "`--comment`: Post the review as a comment on the pull request (default: outputs to terminal only)". The previous CI runs completed successfully ($0.95 each) but produced `No buffered inline comments` because this flag was missing.

## Test plan
- [x] This PR itself will trigger the updated workflow — check if the code review posts a comment