### PR TITLE
fix: add skip filters and progress tracking to code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,20 +3,18 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths:
+      - "src/**"
+      - "docs-site/src/**"
+      - "docs-site/vite.docs.config.ts"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-review') &&
+      !startsWith(github.event.pull_request.title, 'chore:') &&
+      !startsWith(github.event.pull_request.title, 'deps:')
 
     runs-on: ubuntu-latest
     permissions:
@@ -39,5 +37,6 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          track_progress: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- Only trigger code review on source changes (`src/**`, `docs-site/src/**`, `docs-site/vite.docs.config.ts`)
- Skip draft PRs, `chore:`/`deps:` prefixed titles, and `skip-review` labeled PRs
- Enable `track_progress` for live progress comments on PRs

## Skip methods
| Method | How |
|---|---|
| Path filter | PRs only touching lockfiles, docs, CI config won't trigger |
| Draft PR | Open as draft until ready |
| Label | Add `skip-review` label |
| Title prefix | Start with `chore:` or `deps:` |

## Test plan
- [x] This PR only touches `.github/` — code review should **not** trigger (path filter)