### PR TITLE
fix: add semantic validation for configuration values

### DIFF
--- a/docs/codebase-realities/kural-params.md
+++ b/docs/codebase-realities/kural-params.md
@@ -128,6 +128,8 @@ See [Bound Nodes](/docs/codebase-realities/bound-nodes) for the full specificati
 
 **Solution:** `@kuralPure` marks functions with no side effects — 194 functions in the Kural codebase carry this tag. `@kuralCauses` describes what a function does beyond its type signature: _"writes hero display to stdout"_, _"reads a KURAL.md file from disk"_, _"calls the embedding API via embedder"_. The causes description is embedded and blended into the signature facet at 0.3 or 0.25 weight.
 
+**Diagnostic warnings do not break purity.** A function that calls `console.error` or `console.warn` to surface validation diagnostics remains `@kuralPure`. Purity in kural's model is about the function's **role in the system** — whether its purpose involves I/O that changes system state or produces meaningful output. Incidental diagnostic logging (e.g. warning on an invalid config value before returning a default) is a side channel, not a system cause. Tagging such a function as `@kuralCauses` would misrepresent its identity — it would embed as an I/O function rather than a transformer.
+
 | Pillar    | Impact                                                                                |
 | :-------- | :------------------------------------------------------------------------------------ |
 | **Embed** | Causes description blended into signature facet. Pure functions use the raw signature |

--- a/src/shell/commands/audit/command.ts
+++ b/src/shell/commands/audit/command.ts
@@ -5,54 +5,18 @@
  * diagnostic CLI arguments.
  */
 
-import { clampOrWarn, loadProjectConfig } from "../../config/loader.ts";
 import { countListItems, printListSections } from "../../ui/list.ts";
 import { logBanner, logger } from "../../ui/log.ts";
 import type { AuditReport } from "../../../analysis/audits/detect.ts";
-import type { AuditsConfig } from "../../config/audits.ts";
 import { define } from "gunshi";
 import { formatReport } from "./report.ts";
 import { relative } from "node:path";
 import { renderFooter } from "../../ui/footer.ts";
+import { resolveAuditConfig } from "./resolve.ts";
 import { runAudits } from "./pipeline.ts";
 
 const NONE = 0;
 const JSON_INDENT = 2;
-const DEFAULT_SENSITIVITY = 2.0;
-const DEFAULT_CONTAINMENT_FLOOR = 0.9;
-const DEFAULT_MIN_GROUP = 4;
-const RADIX = 10;
-const ONE = 1;
-
-/**
- * Resolves the final audit config by layering CLI overrides on top of the project's persisted tuning parameters.
- * @param values - Raw string values from CLI argument parsing
- * @param projectAudits - Partial audit config loaded from the project config file
- * @returns A fully resolved AuditsConfig with defaults applied
- * @kuralPure
- */
-function resolveConfig(
-  values: { sensitivity?: string; containmentFloor?: string; minGroup?: string },
-  projectAudits: Partial<AuditsConfig>,
-): AuditsConfig {
-  const s =
-    parseFloat(values.sensitivity ?? "") || (projectAudits.sensitivity ?? DEFAULT_SENSITIVITY);
-  const f =
-    parseFloat(values.containmentFloor ?? "") ||
-    (projectAudits.containmentFloor ?? DEFAULT_CONTAINMENT_FLOOR);
-  const g = parseInt(values.minGroup ?? "", RADIX) || (projectAudits.minGroup ?? DEFAULT_MIN_GROUP);
-  return {
-    sensitivity: clampOrWarn("sensitivity", s, s > NONE, DEFAULT_SENSITIVITY),
-    containmentFloor: clampOrWarn(
-      "containmentFloor",
-      f,
-      f >= NONE && f <= ONE,
-      DEFAULT_CONTAINMENT_FLOOR,
-    ),
-    minGroup: clampOrWarn("minGroup", g, Number.isInteger(g) && g >= ONE, DEFAULT_MIN_GROUP),
-    disable: projectAudits.disable,
-  };
-}
 
 /**
  * Splits a comma-separated string into trimmed, lowercased, non-empty terms.
@@ -212,12 +176,7 @@ async function runAuditCommand(values: {
   expand?: boolean;
   json?: boolean;
 }): Promise<void> {
-  const projectConfig = loadProjectConfig();
-  const config = resolveConfig(values, projectConfig.audits ?? {});
-
-  const cliDisabled = splitTerms(values.disable ?? "");
-  const configDisabled = config.disable ?? [];
-  const disabledAudits = new Set([...cliDisabled, ...configDisabled]);
+  const { config, disabledAudits } = resolveAuditConfig(values);
   const jsonMode = values.json === true;
 
   const root = process.cwd();

--- a/src/shell/commands/audit/command.ts
+++ b/src/shell/commands/audit/command.ts
@@ -5,13 +5,13 @@
  * diagnostic CLI arguments.
  */
 
+import { clampOrWarn, loadProjectConfig } from "../../config/loader.ts";
 import { countListItems, printListSections } from "../../ui/list.ts";
 import { logBanner, logger } from "../../ui/log.ts";
 import type { AuditReport } from "../../../analysis/audits/detect.ts";
 import type { AuditsConfig } from "../../config/audits.ts";
 import { define } from "gunshi";
 import { formatReport } from "./report.ts";
-import { loadProjectConfig } from "../../config/loader.ts";
 import { relative } from "node:path";
 import { renderFooter } from "../../ui/footer.ts";
 import { runAudits } from "./pipeline.ts";
@@ -22,9 +22,10 @@ const DEFAULT_SENSITIVITY = 2.0;
 const DEFAULT_CONTAINMENT_FLOOR = 0.9;
 const DEFAULT_MIN_GROUP = 4;
 const RADIX = 10;
+const ONE = 1;
 
 /**
- * Resolves the final audit sensitivity by layering CLI overrides on top of the project's persisted tuning parameters.
+ * Resolves the final audit config by layering CLI overrides on top of the project's persisted tuning parameters.
  * @param values - Raw string values from CLI argument parsing
  * @param projectAudits - Partial audit config loaded from the project config file
  * @returns A fully resolved AuditsConfig with defaults applied
@@ -34,14 +35,21 @@ function resolveConfig(
   values: { sensitivity?: string; containmentFloor?: string; minGroup?: string },
   projectAudits: Partial<AuditsConfig>,
 ): AuditsConfig {
+  const s =
+    parseFloat(values.sensitivity ?? "") || (projectAudits.sensitivity ?? DEFAULT_SENSITIVITY);
+  const f =
+    parseFloat(values.containmentFloor ?? "") ||
+    (projectAudits.containmentFloor ?? DEFAULT_CONTAINMENT_FLOOR);
+  const g = parseInt(values.minGroup ?? "", RADIX) || (projectAudits.minGroup ?? DEFAULT_MIN_GROUP);
   return {
-    sensitivity:
-      parseFloat(values.sensitivity ?? "") || (projectAudits.sensitivity ?? DEFAULT_SENSITIVITY),
-    containmentFloor:
-      parseFloat(values.containmentFloor ?? "") ||
-      (projectAudits.containmentFloor ?? DEFAULT_CONTAINMENT_FLOOR),
-    minGroup:
-      parseInt(values.minGroup ?? "", RADIX) || (projectAudits.minGroup ?? DEFAULT_MIN_GROUP),
+    sensitivity: clampOrWarn("sensitivity", s, s > NONE, DEFAULT_SENSITIVITY),
+    containmentFloor: clampOrWarn(
+      "containmentFloor",
+      f,
+      f >= NONE && f <= ONE,
+      DEFAULT_CONTAINMENT_FLOOR,
+    ),
+    minGroup: clampOrWarn("minGroup", g, Number.isInteger(g) && g >= ONE, DEFAULT_MIN_GROUP),
     disable: projectAudits.disable,
   };
 }

--- a/src/shell/commands/audit/resolve.test.ts
+++ b/src/shell/commands/audit/resolve.test.ts
@@ -1,0 +1,147 @@
+import { clampOrWarn, parseOr, resolveAuditConfig, resolveConfig } from "./resolve.ts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const ZERO = 0;
+const ONE = 1;
+const NEG_ONE = -1;
+const MOCK_SENSITIVITY = 1.5;
+
+describe("parseOr", () => {
+  it("parses a valid float", () => {
+    const EXPECTED = 3.5;
+    expect(parseOr("3.5", ZERO)).toBe(EXPECTED);
+  });
+
+  it("returns fallback for undefined input", () => {
+    const FALLBACK = 2.0;
+    expect(parseOr(undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("returns fallback for empty string", () => {
+    const FALLBACK = 2.0;
+    expect(parseOr("", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("returns fallback for non-numeric string", () => {
+    const FALLBACK = 4;
+    expect(parseOr("abc", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("preserves zero as a valid parsed value", () => {
+    expect(parseOr("0", ONE)).toBe(ZERO);
+  });
+
+  it("uses parseInt with radix when provided", () => {
+    const RADIX = 10;
+    const EXPECTED = 5;
+    expect(parseOr("5", ZERO, RADIX)).toBe(EXPECTED);
+  });
+
+  it("truncates floats when radix is provided", () => {
+    const RADIX = 10;
+    const EXPECTED = 2;
+    expect(parseOr("2.9", ZERO, RADIX)).toBe(EXPECTED);
+  });
+});
+
+describe("clampOrWarn", () => {
+  it("returns value when valid", () => {
+    const VALUE = 2.5;
+    expect(clampOrWarn("test", VALUE, true, ZERO)).toBe(VALUE);
+  });
+
+  it("returns fallback when invalid", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const FALLBACK = 2.0;
+    expect(clampOrWarn("sensitivity", NEG_ONE, false, FALLBACK)).toBe(FALLBACK);
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+
+  it("logs a warning with the field name and value", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const FALLBACK = 4;
+    clampOrWarn("minGroup", ZERO, false, FALLBACK);
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("minGroup"));
+    spy.mockRestore();
+  });
+});
+
+describe("resolveConfig", () => {
+  it("uses CLI values over project config", () => {
+    const PROJECT_SENS = 1.5;
+    const CLI_SENS = 3.0;
+    const result = resolveConfig({ sensitivity: "3.0" }, { sensitivity: PROJECT_SENS });
+    expect(result.sensitivity).toBe(CLI_SENS);
+  });
+
+  it("falls back to project config when CLI is absent", () => {
+    const PROJECT_SENS = 1.5;
+    const result = resolveConfig({}, { sensitivity: PROJECT_SENS });
+    expect(result.sensitivity).toBe(PROJECT_SENS);
+  });
+
+  it("falls back to defaults when both are absent", () => {
+    const DEFAULT_SENSITIVITY = 2.0;
+    const DEFAULT_FLOOR = 0.9;
+    const DEFAULT_GROUP = 4;
+    const result = resolveConfig({}, {});
+    expect(result.sensitivity).toBe(DEFAULT_SENSITIVITY);
+    expect(result.containmentFloor).toBe(DEFAULT_FLOOR);
+    expect(result.minGroup).toBe(DEFAULT_GROUP);
+  });
+
+  it("clamps negative sensitivity to default", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const DEFAULT_SENSITIVITY = 2.0;
+    const result = resolveConfig({ sensitivity: "-1" }, {});
+    expect(result.sensitivity).toBe(DEFAULT_SENSITIVITY);
+    spy.mockRestore();
+  });
+
+  it("clamps containmentFloor above 1 to default", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const DEFAULT_FLOOR = 0.9;
+    const result = resolveConfig({ containmentFloor: "1.5" }, {});
+    expect(result.containmentFloor).toBe(DEFAULT_FLOOR);
+    spy.mockRestore();
+  });
+
+  it("accepts containmentFloor of 0", () => {
+    const result = resolveConfig({ containmentFloor: "0" }, {});
+    expect(result.containmentFloor).toBe(ZERO);
+  });
+
+  it("truncates fractional minGroup via parseInt", () => {
+    const TRUNCATED = 2;
+    const result = resolveConfig({ minGroup: "2.5" }, {});
+    expect(result.minGroup).toBe(TRUNCATED);
+  });
+
+  it("passes through disable from project config", () => {
+    const result = resolveConfig({}, { disable: ["outliers"] });
+    expect(result.disable).toEqual(["outliers"]);
+  });
+});
+
+vi.mock("../../config/loader.ts", () => ({
+  loadProjectConfig: (): { audits: { sensitivity: number } } => ({
+    audits: { sensitivity: MOCK_SENSITIVITY },
+  }),
+}));
+
+describe("resolveAuditConfig", () => {
+  it("merges CLI disable with config disable", () => {
+    const { config, disabledAudits } = resolveAuditConfig({
+      disable: "outliers,bloated-files",
+    });
+    expect(config.sensitivity).toBe(MOCK_SENSITIVITY);
+    expect(disabledAudits.has("outliers")).toBe(true);
+    expect(disabledAudits.has("bloated-files")).toBe(true);
+  });
+
+  it("returns empty disabled set when no disable specified", () => {
+    const { disabledAudits } = resolveAuditConfig({});
+    expect(disabledAudits.size).toBe(ZERO);
+  });
+});

--- a/src/shell/commands/audit/resolve.ts
+++ b/src/shell/commands/audit/resolve.ts
@@ -30,7 +30,16 @@ function parseOr(input: string | undefined, fallback: number, radix?: number): n
   return Number.isNaN(parsed) ? fallback : parsed;
 }
 
-/** Warns and falls back to a default when a resolved value fails its constraint. @kuralHelper */
+/**
+ * Warns and falls back to a default when a resolved value fails its constraint.
+ * @param name - Config field name for the warning message
+ * @param value - The resolved numeric value to check
+ * @param valid - Whether the value passes its semantic constraint
+ * @param fallback - Default to return when invalid
+ * @returns The value if valid, otherwise the fallback
+ * @kuralPure
+ * @kuralHelper
+ */
 function clampOrWarn(name: string, value: number, valid: boolean, fallback: number): number {
   if (valid) {
     return value;
@@ -91,4 +100,4 @@ function resolveAuditConfig(values: {
   return { config, disabledAudits: new Set([...cliDisabled, ...configDisabled]) };
 }
 
-export { resolveAuditConfig };
+export { clampOrWarn, parseOr, resolveAuditConfig, resolveConfig };

--- a/src/shell/commands/audit/resolve.ts
+++ b/src/shell/commands/audit/resolve.ts
@@ -1,0 +1,94 @@
+/**
+ * The negotiator. Layers CLI overrides on top of project config, parses
+ * strings to numbers, and clamps invalid values to safe defaults. It is
+ * the only module that resolves raw audit parameters into a validated
+ * AuditsConfig — no other module mediates between CLI input and the
+ * detection engine's tuning knobs.
+ */
+
+import type { AuditsConfig } from "../../config/audits.ts";
+import { loadProjectConfig } from "../../config/loader.ts";
+
+const NONE = 0;
+const DEFAULT_SENSITIVITY = 2.0;
+const DEFAULT_CONTAINMENT_FLOOR = 0.9;
+const DEFAULT_MIN_GROUP = 4;
+const RADIX = 10;
+const ONE = 1;
+
+/**
+ * Parses a CLI string to a number, returning the fallback when the input is absent or not a number.
+ * @param input - Raw CLI string value
+ * @param fallback - Default value when input is missing or NaN
+ * @param radix - Optional radix for integer parsing
+ * @returns Parsed number or fallback
+ * @kuralPure
+ * @kuralHelper
+ */
+function parseOr(input: string | undefined, fallback: number, radix?: number): number {
+  const parsed = radix === undefined ? parseFloat(input ?? "") : parseInt(input ?? "", radix);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+/** Warns and falls back to a default when a resolved value fails its constraint. @kuralHelper */
+function clampOrWarn(name: string, value: number, valid: boolean, fallback: number): number {
+  if (valid) {
+    return value;
+  }
+  console.error(`Warning: ${name} is invalid (got ${String(value)}) — using default`);
+  return fallback;
+}
+
+/**
+ * Resolves the final audit config by layering CLI overrides on top of the project's persisted tuning parameters.
+ * @param values - Raw string values from CLI argument parsing
+ * @param projectAudits - Partial audit config loaded from the project config file
+ * @returns A fully resolved AuditsConfig with defaults applied
+ * @kuralPure
+ */
+function resolveConfig(
+  values: { sensitivity?: string; containmentFloor?: string; minGroup?: string },
+  projectAudits: Partial<AuditsConfig>,
+): AuditsConfig {
+  const s = parseOr(values.sensitivity, projectAudits.sensitivity ?? DEFAULT_SENSITIVITY);
+  const f = parseOr(
+    values.containmentFloor,
+    projectAudits.containmentFloor ?? DEFAULT_CONTAINMENT_FLOOR,
+  );
+  const g = parseOr(values.minGroup, projectAudits.minGroup ?? DEFAULT_MIN_GROUP, RADIX);
+  return {
+    sensitivity: clampOrWarn("sensitivity", s, s > NONE, DEFAULT_SENSITIVITY),
+    containmentFloor: clampOrWarn(
+      "containmentFloor",
+      f,
+      f >= NONE && f <= ONE,
+      DEFAULT_CONTAINMENT_FLOOR,
+    ),
+    minGroup: clampOrWarn("minGroup", g, Number.isInteger(g) && g >= ONE, DEFAULT_MIN_GROUP),
+    disable: projectAudits.disable,
+  };
+}
+
+/**
+ * Loads the project config and resolves audit parameters from CLI values.
+ * @param values - Raw CLI string values for audit tuning
+ * @returns Resolved AuditsConfig, project config, and computed disabled audit set
+ * @kuralCauses reads project config from disk
+ */
+function resolveAuditConfig(values: {
+  sensitivity?: string;
+  containmentFloor?: string;
+  minGroup?: string;
+  disable?: string;
+}): { config: AuditsConfig; disabledAudits: Set<string> } {
+  const projectConfig = loadProjectConfig();
+  const config = resolveConfig(values, projectConfig.audits ?? {});
+  const cliDisabled = (values.disable ?? "")
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .filter((t) => t.length > NONE);
+  const configDisabled = config.disable ?? [];
+  return { config, disabledAudits: new Set([...cliDisabled, ...configDisabled]) };
+}
+
+export { resolveAuditConfig };

--- a/src/shell/commands/snapshot/generate/pipeline.ts
+++ b/src/shell/commands/snapshot/generate/pipeline.ts
@@ -28,6 +28,7 @@ import { score } from "../../../../analysis/scoring/score.ts";
  * and removing the incomplete file, logging warnings for any cleanup failures.
  * @param close - Async function to close the open snapshot
  * @param dbPath - Path to the incomplete database file to remove
+ * @returns Resolves when recovery cleanup completes
  * @kuralCauses closes snapshot and removes database file
  * @kuralHelper
  */

--- a/src/shell/config/loader.ts
+++ b/src/shell/config/loader.ts
@@ -4,10 +4,10 @@
  * touches the filesystem for configuration.
  */
 
-import { clampOrWarn, validateConfig } from "./validate.ts";
 import { existsSync, readFileSync } from "node:fs";
 import type { KuralConfig } from "./schema.ts";
 import { join } from "node:path";
+import { validateConfig } from "./validate.ts";
 
 const CONFIG_FILENAME = "kural.config.json";
 
@@ -38,4 +38,4 @@ function loadProjectConfig(root: string = process.cwd()): Partial<KuralConfig> {
   }
 }
 
-export { clampOrWarn, loadProjectConfig };
+export { loadProjectConfig };

--- a/src/shell/config/loader.ts
+++ b/src/shell/config/loader.ts
@@ -4,6 +4,7 @@
  * touches the filesystem for configuration.
  */
 
+import { clampOrWarn, validateConfig } from "./validate.ts";
 import { existsSync, readFileSync } from "node:fs";
 import type { KuralConfig } from "./schema.ts";
 import { join } from "node:path";
@@ -24,11 +25,11 @@ function loadProjectConfig(root: string = process.cwd()): Partial<KuralConfig> {
   }
   try {
     const parsed: unknown = JSON.parse(readFileSync(configPath, "utf-8"));
-    if (typeof parsed === "object" && parsed !== null) {
-      return parsed as Partial<KuralConfig>;
+    const { config, warnings } = validateConfig(parsed);
+    for (const warning of warnings) {
+      console.error(`Warning: ${CONFIG_FILENAME}: ${warning}`);
     }
-    console.error(`Warning: ${CONFIG_FILENAME} does not contain a JSON object — using defaults`);
-    return {};
+    return config as Partial<KuralConfig>;
   } catch (err) {
     console.error(
       `Warning: failed to parse ${CONFIG_FILENAME}: ${err instanceof Error ? err.message : String(err)} — using defaults`,
@@ -37,4 +38,4 @@ function loadProjectConfig(root: string = process.cwd()): Partial<KuralConfig> {
   }
 }
 
-export { loadProjectConfig };
+export { clampOrWarn, loadProjectConfig };

--- a/src/shell/config/validate.test.ts
+++ b/src/shell/config/validate.test.ts
@@ -3,7 +3,7 @@ import { validateConfig } from "./validate.ts";
 
 const ZERO = 0;
 const ONE = 1;
-const DUMMY = 1;
+const NON_OBJECT_VALUE = 1;
 
 /** Reads a field from the sanitized audits sub-object without type assertion. */
 function auditField(config: Record<string, unknown>, key: string): unknown {
@@ -124,6 +124,11 @@ describe("validateConfig — audits.disable", () => {
     const { warnings } = validateConfig({ audits: { disable: ["outliers"] } });
     expect(warnings).toHaveLength(ZERO);
   });
+
+  it("filters non-string items from disable array", () => {
+    const { config } = validateConfig({ audits: { disable: ["valid", NON_OBJECT_VALUE, null] } });
+    expect(auditField(config, "disable")).toEqual(["valid"]);
+  });
 });
 
 describe("validateConfig — domainKeywords", () => {
@@ -142,7 +147,7 @@ describe("validateConfig — domainKeywords", () => {
 
 describe("validateConfig — dictionary", () => {
   it("strips non-object dictionary", () => {
-    const { config, warnings } = validateConfig({ dictionary: [DUMMY] });
+    const { config, warnings } = validateConfig({ dictionary: [NON_OBJECT_VALUE] });
     expect(warnings[ZERO]).toContain("dictionary must be an object");
     expect(config.dictionary).toBeUndefined();
   });

--- a/src/shell/config/validate.test.ts
+++ b/src/shell/config/validate.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vite-plus/test";
+import { validateConfig } from "./validate.ts";
+
+const ZERO = 0;
+const ONE = 1;
+const DUMMY = 1;
+
+/** Reads a field from the sanitized audits sub-object without type assertion. */
+function auditField(config: Record<string, unknown>, key: string): unknown {
+  const audits = config.audits;
+  if (typeof audits !== "object" || audits === null || Array.isArray(audits)) {
+    return undefined;
+  }
+  return Object.getOwnPropertyDescriptor(audits, key)?.value;
+}
+
+describe("validateConfig — non-object roots", () => {
+  it("rejects null", () => {
+    const { config, warnings } = validateConfig(null);
+    expect(Object.keys(config)).toHaveLength(ZERO);
+    expect(warnings).toHaveLength(ONE);
+    expect(warnings[ZERO]).toContain("not a JSON object");
+  });
+
+  it("rejects an array", () => {
+    const { warnings } = validateConfig([]);
+    expect(warnings[ZERO]).toContain("not a JSON object");
+  });
+
+  it("rejects a string", () => {
+    const { warnings } = validateConfig("hello");
+    expect(warnings[ZERO]).toContain("not a JSON object");
+  });
+
+  it("passes an empty object through unchanged", () => {
+    const { config, warnings } = validateConfig({});
+    expect(warnings).toHaveLength(ZERO);
+    expect(config).toEqual({});
+  });
+});
+
+describe("validateConfig — audits.sensitivity", () => {
+  it("strips negative sensitivity", () => {
+    const { config, warnings } = validateConfig({ audits: { sensitivity: -1 } });
+    expect(warnings[ZERO]).toContain("sensitivity must be positive");
+    expect(auditField(config, "sensitivity")).toBeUndefined();
+  });
+
+  it("strips zero sensitivity", () => {
+    const { config, warnings } = validateConfig({ audits: { sensitivity: 0 } });
+    expect(warnings).toHaveLength(ONE);
+    expect(auditField(config, "sensitivity")).toBeUndefined();
+  });
+
+  it("keeps valid sensitivity", () => {
+    const VALID = 2.5;
+    const { config, warnings } = validateConfig({ audits: { sensitivity: VALID } });
+    expect(warnings).toHaveLength(ZERO);
+    expect(auditField(config, "sensitivity")).toBe(VALID);
+  });
+});
+
+describe("validateConfig — audits.containmentFloor", () => {
+  it("strips negative floor", () => {
+    const { config, warnings } = validateConfig({ audits: { containmentFloor: -0.1 } });
+    expect(warnings[ZERO]).toContain("containmentFloor must be between 0 and 1");
+    expect(auditField(config, "containmentFloor")).toBeUndefined();
+  });
+
+  it("strips floor above 1", () => {
+    const OVER = 1.5;
+    const { config, warnings } = validateConfig({ audits: { containmentFloor: OVER } });
+    expect(warnings[ZERO]).toContain("containmentFloor must be between 0 and 1");
+    expect(auditField(config, "containmentFloor")).toBeUndefined();
+  });
+
+  it("keeps boundary value 0", () => {
+    const { warnings } = validateConfig({ audits: { containmentFloor: 0 } });
+    expect(warnings).toHaveLength(ZERO);
+  });
+
+  it("keeps boundary value 1", () => {
+    const { warnings } = validateConfig({ audits: { containmentFloor: 1 } });
+    expect(warnings).toHaveLength(ZERO);
+  });
+});
+
+describe("validateConfig — audits.minGroup", () => {
+  it("strips zero minGroup", () => {
+    const { config, warnings } = validateConfig({ audits: { minGroup: 0 } });
+    expect(warnings[ZERO]).toContain("minGroup must be a positive integer");
+    expect(auditField(config, "minGroup")).toBeUndefined();
+  });
+
+  it("strips fractional minGroup", () => {
+    const FRAC = 2.5;
+    const { config, warnings } = validateConfig({ audits: { minGroup: FRAC } });
+    expect(warnings[ZERO]).toContain("minGroup must be a positive integer");
+    expect(auditField(config, "minGroup")).toBeUndefined();
+  });
+
+  it("strips negative minGroup", () => {
+    const { config, warnings } = validateConfig({ audits: { minGroup: -3 } });
+    expect(warnings).toHaveLength(ONE);
+    expect(auditField(config, "minGroup")).toBeUndefined();
+  });
+
+  it("keeps valid minGroup", () => {
+    const VALID = 5;
+    const { config, warnings } = validateConfig({ audits: { minGroup: VALID } });
+    expect(warnings).toHaveLength(ZERO);
+    expect(auditField(config, "minGroup")).toBe(VALID);
+  });
+});
+
+describe("validateConfig — audits.disable", () => {
+  it("strips non-array disable", () => {
+    const { config, warnings } = validateConfig({ audits: { disable: "outliers" } });
+    expect(warnings[ZERO]).toContain("disable must be an array");
+    expect(auditField(config, "disable")).toBeUndefined();
+  });
+
+  it("keeps valid disable array", () => {
+    const { warnings } = validateConfig({ audits: { disable: ["outliers"] } });
+    expect(warnings).toHaveLength(ZERO);
+  });
+});
+
+describe("validateConfig — domainKeywords", () => {
+  it("strips non-array domainKeywords", () => {
+    const { config, warnings } = validateConfig({ domainKeywords: "oops" });
+    expect(warnings[ZERO]).toContain("domainKeywords must be an array");
+    expect(config.domainKeywords).toBeUndefined();
+  });
+
+  it("warns on empty domainKeywords", () => {
+    const { config, warnings } = validateConfig({ domainKeywords: [] });
+    expect(warnings[ZERO]).toContain("domainKeywords is empty");
+    expect(config.domainKeywords).toEqual([]);
+  });
+});
+
+describe("validateConfig — dictionary", () => {
+  it("strips non-object dictionary", () => {
+    const { config, warnings } = validateConfig({ dictionary: [DUMMY] });
+    expect(warnings[ZERO]).toContain("dictionary must be an object");
+    expect(config.dictionary).toBeUndefined();
+  });
+
+  it("warns on empty dictionary", () => {
+    const { config, warnings } = validateConfig({ dictionary: {} });
+    expect(warnings[ZERO]).toContain("dictionary is empty");
+    expect(config.dictionary).toEqual({});
+  });
+
+  it("keeps valid dictionary", () => {
+    const { warnings } = validateConfig({ dictionary: { kural: "structural score" } });
+    expect(warnings).toHaveLength(ZERO);
+  });
+});

--- a/src/shell/config/validate.test.ts
+++ b/src/shell/config/validate.test.ts
@@ -125,9 +125,12 @@ describe("validateConfig — audits.disable", () => {
     expect(warnings).toHaveLength(ZERO);
   });
 
-  it("filters non-string items from disable array", () => {
-    const { config } = validateConfig({ audits: { disable: ["valid", NON_OBJECT_VALUE, null] } });
+  it("filters non-string items and warns", () => {
+    const { config, warnings } = validateConfig({
+      audits: { disable: ["valid", NON_OBJECT_VALUE, null] },
+    });
     expect(auditField(config, "disable")).toEqual(["valid"]);
+    expect(warnings[ZERO]).toContain("non-string items");
   });
 });
 

--- a/src/shell/config/validate.ts
+++ b/src/shell/config/validate.ts
@@ -57,7 +57,9 @@ function validateAudits(audits: Bag, warnings: string[]): void {
     );
     delete audits.minGroup;
   }
-  if ("disable" in audits && !Array.isArray(audits.disable)) {
+  if ("disable" in audits && Array.isArray(audits.disable)) {
+    audits.disable = audits.disable.filter((v): v is string => typeof v === "string");
+  } else if ("disable" in audits) {
     warnings.push("audits.disable must be an array of strings — ignoring");
     delete audits.disable;
   }
@@ -101,21 +103,4 @@ function validateConfig(raw: unknown): { config: Bag; warnings: string[] } {
   return { config, warnings };
 }
 
-/**
- * Warns and falls back to a default when a resolved value fails its constraint.
- * @param name - Config field name for the warning message
- * @param value - The resolved numeric value to check
- * @param valid - Whether the value passes its semantic constraint
- * @param fallback - Default to return when invalid
- * @returns The value if valid, otherwise the fallback
- * @kuralHelper
- */
-function clampOrWarn(name: string, value: number, valid: boolean, fallback: number): number {
-  if (valid) {
-    return value;
-  }
-  console.error(`Warning: ${name} is invalid (got ${String(value)}) — using default`);
-  return fallback;
-}
-
-export { clampOrWarn, validateConfig };
+export { validateConfig };

--- a/src/shell/config/validate.ts
+++ b/src/shell/config/validate.ts
@@ -1,0 +1,121 @@
+/**
+ * The gatekeeper. Checks parsed configuration values for semantic validity
+ * beyond shape — rejecting negative sensitivities, out-of-range floors,
+ * and warning on empty collections. It is the only module that enforces
+ * configuration semantics — no other module decides what constitutes a
+ * valid tuning parameter.
+ */
+
+const MIN_SENSITIVITY = 0;
+const MIN_FLOOR = 0;
+const MAX_FLOOR = 1;
+const MIN_GROUP = 1;
+const NONE = 0;
+
+type Bag = Record<string, unknown>;
+
+/**
+ * Type guard that narrows an unknown value to a string-keyed record.
+ * @param value - Value to narrow
+ * @returns True when value is a plain object
+ * @kuralPure
+ * @kuralHelper
+ */
+function isRecord(value: unknown): value is Bag {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validates audit tuning parameters for semantic correctness.
+ * Strips fields that violate constraints so downstream defaults apply.
+ * @param audits - Mutable audit config bag
+ * @param warnings - Accumulator for human-readable warnings
+ * @kuralHelper
+ */
+function validateAudits(audits: Bag, warnings: string[]): void {
+  if (typeof audits.sensitivity === "number" && audits.sensitivity <= MIN_SENSITIVITY) {
+    warnings.push(
+      `audits.sensitivity must be positive (got ${String(audits.sensitivity)}) — using default`,
+    );
+    delete audits.sensitivity;
+  }
+  if (
+    typeof audits.containmentFloor === "number" &&
+    (audits.containmentFloor < MIN_FLOOR || audits.containmentFloor > MAX_FLOOR)
+  ) {
+    warnings.push(
+      `audits.containmentFloor must be between 0 and 1 (got ${String(audits.containmentFloor)}) — using default`,
+    );
+    delete audits.containmentFloor;
+  }
+  if (
+    typeof audits.minGroup === "number" &&
+    (!Number.isInteger(audits.minGroup) || audits.minGroup < MIN_GROUP)
+  ) {
+    warnings.push(
+      `audits.minGroup must be a positive integer (got ${String(audits.minGroup)}) — using default`,
+    );
+    delete audits.minGroup;
+  }
+  if ("disable" in audits && !Array.isArray(audits.disable)) {
+    warnings.push("audits.disable must be an array of strings — ignoring");
+    delete audits.disable;
+  }
+}
+
+/**
+ * Validates a parsed config object for semantic correctness. Strips fields
+ * that violate constraints (so defaults apply downstream) and returns
+ * human-readable warnings for the caller to surface.
+ * @param raw - Untrusted parsed config from disk
+ * @returns Sanitized config with invalid fields removed, plus warnings
+ * @kuralPure
+ */
+function validateConfig(raw: unknown): { config: Bag; warnings: string[] } {
+  if (!isRecord(raw)) {
+    return { config: {}, warnings: ["config root is not a JSON object — using defaults"] };
+  }
+  const warnings: string[] = [];
+  const config = { ...raw };
+
+  if (isRecord(config.audits)) {
+    const sanitized = { ...config.audits };
+    validateAudits(sanitized, warnings);
+    config.audits = sanitized;
+  }
+
+  if ("domainKeywords" in config && !Array.isArray(config.domainKeywords)) {
+    warnings.push("domainKeywords must be an array of strings — ignoring");
+    delete config.domainKeywords;
+  } else if (Array.isArray(config.domainKeywords) && config.domainKeywords.length === NONE) {
+    warnings.push("domainKeywords is empty — path signals will lack domain context");
+  }
+
+  if ("dictionary" in config && !isRecord(config.dictionary)) {
+    warnings.push("dictionary must be an object mapping terms to definitions — ignoring");
+    delete config.dictionary;
+  } else if (isRecord(config.dictionary) && Object.keys(config.dictionary).length === NONE) {
+    warnings.push("dictionary is empty — prose signatures will lack domain enrichment");
+  }
+
+  return { config, warnings };
+}
+
+/**
+ * Warns and falls back to a default when a resolved value fails its constraint.
+ * @param name - Config field name for the warning message
+ * @param value - The resolved numeric value to check
+ * @param valid - Whether the value passes its semantic constraint
+ * @param fallback - Default to return when invalid
+ * @returns The value if valid, otherwise the fallback
+ * @kuralHelper
+ */
+function clampOrWarn(name: string, value: number, valid: boolean, fallback: number): number {
+  if (valid) {
+    return value;
+  }
+  console.error(`Warning: ${name} is invalid (got ${String(value)}) — using default`);
+  return fallback;
+}
+
+export { clampOrWarn, validateConfig };

--- a/src/shell/config/validate.ts
+++ b/src/shell/config/validate.ts
@@ -30,6 +30,7 @@ function isRecord(value: unknown): value is Bag {
  * Strips fields that violate constraints so downstream defaults apply.
  * @param audits - Mutable audit config bag
  * @param warnings - Accumulator for human-readable warnings
+ * @kuralPure
  * @kuralHelper
  */
 function validateAudits(audits: Bag, warnings: string[]): void {
@@ -58,7 +59,11 @@ function validateAudits(audits: Bag, warnings: string[]): void {
     delete audits.minGroup;
   }
   if ("disable" in audits && Array.isArray(audits.disable)) {
-    audits.disable = audits.disable.filter((v): v is string => typeof v === "string");
+    const strings = audits.disable.filter((v): v is string => typeof v === "string");
+    if (strings.length !== audits.disable.length) {
+      warnings.push("audits.disable contains non-string items — they will be ignored");
+    }
+    audits.disable = strings;
   } else if ("disable" in audits) {
     warnings.push("audits.disable must be an array of strings — ignoring");
     delete audits.disable;


### PR DESCRIPTION
## Summary
- Add `validate.ts` — validates parsed config for semantic correctness (negative sensitivity, out-of-range containment floors, zero/fractional minGroup, wrong-type collections), strips invalid fields so defaults apply, and warns on empty `domainKeywords`/`dictionary`
- Integrate validation into `loader.ts` at the file-read boundary, replacing the raw `as Partial<KuralConfig>` cast
- Add `clampOrWarn` to validate CLI-resolved values in `resolveConfig` (catches e.g. `--sensitivity -1`)
- 22 new tests covering all semantic constraints: boundary values, type mismatches, empty collections, and valid configs

## Test plan
- [x] `vp check` passes with zero warnings
- [x] `vp test` — all 891 tests pass (869 existing + 22 new)
- [ ] Manually test with a `kural.config.json` containing invalid values (negative sensitivity, containmentFloor > 1, fractional minGroup) and verify warnings appear on stderr