### PR TITLE
refactor: self-calibrate thresholds and internalize constraints

### DIFF
--- a/docs/pillars/audits.mdx
+++ b/docs/pillars/audits.mdx
@@ -30,7 +30,7 @@ robustUpperFence = median + sensitivity × 1.4826 × MAD
 robustLowerFence = median - sensitivity × 1.4826 × MAD
 ```
 
-MAD (Median Absolute Deviation) resists outliers better than standard deviation. The constant 1.4826 makes MAD consistent with σ for normal data. A minimum MAD of `0.5 / √d` (half the noise floor of cosine similarity for d-dimensional vectors) prevents collapse on uniform distributions. Used for outlier detection, vocabulary bleed, and identity language.
+MAD (Median Absolute Deviation) resists outliers better than standard deviation. The constant 1.4826 makes MAD consistent with σ for normal data. When more than half the values are identical, MAD collapses to zero — the fence falls back to IQR/2 (the MAD-equivalent under normality, since IQR ≈ 2·MAD). When both MAD and IQR are zero (all values identical), there is no variation and the fence returns its sentinel — no outliers exist. Used for outlier detection, vocabulary bleed, and identity language.
 
 ### Dendrogram gap
 

--- a/docs/pillars/audits.mdx
+++ b/docs/pillars/audits.mdx
@@ -30,7 +30,7 @@ robustUpperFence = median + sensitivity × 1.4826 × MAD
 robustLowerFence = median - sensitivity × 1.4826 × MAD
 ```
 
-MAD (Median Absolute Deviation) resists outliers better than standard deviation. The constant 1.4826 makes MAD consistent with σ for normal data. A minimum MAD of 0.015 prevents collapse on uniform distributions. Used for outlier detection, vocabulary bleed, and identity language.
+MAD (Median Absolute Deviation) resists outliers better than standard deviation. The constant 1.4826 makes MAD consistent with σ for normal data. A minimum MAD of `0.5 / √d` (half the noise floor of cosine similarity for d-dimensional vectors) prevents collapse on uniform distributions. Used for outlier detection, vocabulary bleed, and identity language.
 
 ### Dendrogram gap
 
@@ -48,7 +48,7 @@ The `sensitivity` parameter (default 2.0) controls how many deviations from cent
 
 ### Bloating & Size
 
-**bloated-directories** — Detects directories whose children cluster into distinct groups via dendrogram gap analysis. Suggests a natural split point for reorganization. In the Kural codebase, `src/` carries `@kuralResidual bloated-directories [070d22b3]` because its breadth — spanning ingestion, scoring, audits, storage, commands, and UI — is the intended architecture.
+**bloated-directories** — Detects directories whose children cluster into distinct groups via dendrogram gap analysis. Requires at least 3 children to attempt clustering, and each cluster must have at least 3 members to count as substantial. Suggests a natural split point for reorganization. In the Kural codebase, `src/` carries `@kuralResidual bloated-directories [070d22b3]` because its breadth — spanning ingestion, scoring, audits, storage, commands, and UI — is the intended architecture.
 
 **bloated-files** — Same dendrogram logic applied to functions and types within files. Distinguishes type-vs-function splits (natural) from semantic clusters (actionable).
 
@@ -78,13 +78,13 @@ The `sensitivity` parameter (default 2.0) controls how many deviations from cent
 
 ### Documentation & Coherence
 
-**incoherent** — Detects non-util containers whose identity-to-content similarity is a lower outlier. The name and description say one thing; the actual content says another. Capped at 0.9 to avoid flagging near-perfect alignment as an issue.
+**incoherent** — Detects non-util containers whose identity-to-content similarity is a lower outlier. The name and description say one thing; the actual content says another. Capped at the median label-fit to avoid flagging near-perfect alignment as an issue.
 
 **incoherent-utils** — Same logic for util containers, scored within their own population.
 
 **identity-language** — Detects directories whose KURAL.md description leans toward "is" (static identity) instead of "does" (dynamic purpose). Measured against the is-does axis — 60 multilingual anchor sentences from `src/config/axis-anchors.ts`. Flags directories whose axis score falls below a robust lower fence.
 
-**weak-identity** — Detects containers where more than half the children fit a sibling module better than their own parent. Uses the drift ratio — the fraction of children whose uncle fit exceeds parent fit — and flags containers where this ratio is a Z-score upper outlier. Reports the strongest competing uncle and the parent-vs-uncle fit comparison. Requires at least 4 eligible children for the statistical test.
+**weak-identity** — Detects containers where more than half the children fit a sibling module better than their own parent. Uses the drift ratio — the fraction of children whose uncle fit exceeds parent fit — and flags containers where this ratio is a Z-score upper outlier. Reports the strongest competing uncle and the parent-vs-uncle fit comparison. Requires at least 2 eligible children for the statistical test.
 
 **incomplete-docs** — Detects units missing required documentation. Functions need description, `@param`, `@returns`, and `@kuralPure` or `@kuralCauses`. Types need description. Files need file-level JSDoc. Directories need KURAL.md with a description.
 
@@ -151,10 +151,8 @@ Audits run in a defined sequence. The `outliers` audit runs early and populates 
 ```typescript
 {
   sensitivity: 2.0,       // Standard deviations from center (higher = stricter)
-  containmentFloor: 0.9,  // Minimum dominance gap for containment findings
-  minGroup: 4,            // Minimum group size for statistical tests
   disable: []             // Audit names to skip entirely
 }
 ```
 
-Sensitivity is the primary knob. At 2.0, findings are moderate — most real issues surface without excessive noise. At 3.0, only strong outliers are flagged. Below 1.5, expect many findings.
+Sensitivity is the only knob. At 2.0, findings are moderate — most real issues surface without excessive noise. At 3.0, only strong outliers are flagged. Below 1.5, expect many findings. See [Tuning](/docs/pillars/tuning) for how every threshold in the system resolves to `sensitivity`, data, or design intent.

--- a/docs/pillars/meta.json
+++ b/docs/pillars/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Pillars",
   "icon": "Columns3",
-  "pages": ["scoring", "util-scoring", "audits"]
+  "pages": ["scoring", "util-scoring", "audits", "tuning"]
 }

--- a/docs/pillars/tuning.mdx
+++ b/docs/pillars/tuning.mdx
@@ -76,7 +76,7 @@ These are derived from formulas. They are not tuning parameters.
 
 ---
 
-## 4. Definitional Constants (3 constants)
+## 4. Definitional Constants (4 constants)
 
 These follow from the definitions of the concepts they implement.
 
@@ -85,10 +85,11 @@ These follow from the definitions of the concepts they implement.
 | `MIN_SUBSTANTIAL_CLUSTERS` | 2     | `bloated.ts`       | You cannot "split" into fewer than 2 groups. This is the definition of a split.                                                                                                                                                                     |
 | `HALF_RATIO`               | 0.5   | `weak-identity.ts` | "Majority" means more than half. A directory with weak identity is one where >50% of children fit an uncle better. This is a safety floor on top of the statistical fence — even if the fence is permissive, a majority must drift before flagging. |
 | `MIN_PROBES`               | 2     | `calibrate.ts`     | `robustLowerFence` returns &minus;&infin; for fewer than 2 values. Fewer than 2 probes means no calibration is statistically possible.                                                                                                              |
+| `IQR_TO_MAD`               | 2     | `fence.ts`         | IQR &asymp; 2&middot;MAD for normal data. Converts IQR to MAD-equivalent scale as a fallback when MAD collapses to zero.                                                                                                                            |
 
 ---
 
-## 5. Self-Calibrating Thresholds (8 constants)
+## 5. Self-Calibrating Thresholds (7 constants)
 
 These values derive from the codebase's own distributions at runtime. None are user-configurable — they adapt automatically, controlled by `k`. See [Audits](/docs/pillars/audits) for each audit's detection logic.
 
@@ -149,15 +150,9 @@ containmentFloor = robustLowerFence(dominantSims, k)
 
 Computed from the codebase's own parent-child dominance similarities. This eliminated the `--containmentFloor` CLI flag — one less config field, one less thing to explain.
 
-### Embedding noise floor
+### MAD-zero fallback
 
-#### `MIN_MAD`
-
-```
-MIN_MAD = 0.5 / √d
-```
-
-Floor for Median Absolute Deviation to prevent fence collapse when all values are identical. For d-dimensional unit vectors, random cosine similarity has &sigma; &approx; 1/&radic;d. Half that noise floor means "below this, apparent variation is noise, not signal." For 1536-dim (text-embedding-3-small): 0.0128. For 3072-dim: 0.0090.
+When MAD collapses to zero (>50% of values identical), the robust fence falls back to `IQR / 2` — the MAD-equivalent under normality (standard practice in robust statistics). When both MAD and IQR are zero (no variation at all), the fence returns its sentinel value (-Infinity for lower, Infinity for upper), meaning no outliers exist. No magic numbers — the fallback derives from the data itself using the mathematical relationship `IQR ≈ 2 · MAD`.
 
 ---
 
@@ -196,8 +191,8 @@ Softmax temperature in chain search adapts to the branching factor at each routi
 | Single tuning parameter (`k`)     |      1 | User-controlled, governs all fences                    |
 | Embedding weights (design intent) |     13 | Documented rationale, consistent pattern               |
 | Mathematical constants            |      5 | Derived from formulas                                  |
-| Definitional constants            |      3 | Follow from definitions                                |
-| Self-calibrating from data        |      8 | Fence or distribution stat computed at runtime via `k` |
+| Definitional constants            |      4 | Follow from definitions                                |
+| Self-calibrating from data        |      7 | Fence or distribution stat computed at runtime via `k` |
 | Adaptive                          |      1 | Computed per routing step from branching factor        |
 | Display preferences               |      2 | Move to user config                                    |
 | **Total**                         | **33** | **1 tuning parameter, 0 unjustified constants**        |

--- a/docs/pillars/tuning.mdx
+++ b/docs/pillars/tuning.mdx
@@ -1,0 +1,203 @@
+---
+title: Tuning
+description: How every threshold in the system resolves to one parameter, data, or design intent
+icon: SlidersHorizontal
+---
+
+Kural has one tuning parameter: `sensitivity` (`k`). Every other numeric constant in the system either derives from `k`, self-calibrates from the codebase's own distributions, follows from a mathematical formula, or represents a deliberate design choice with documented rationale. This page catalogs all 33 named constants and explains how each one resolves. See [Audits](/docs/pillars/audits) for the full audit reference.
+
+---
+
+## 1. The Single Dial: Sensitivity (`k`)
+
+Every audit, every fence, every detection boundary flows through `k`. The statistical machinery adapts to the codebase's shape automatically — `k` is the only judgment call: how strict should "abnormal" be?
+
+```
+upperFence = mean + k × σ
+lowerFence = mean − k × σ
+robustUpperFence = median + k × 1.4826 × MAD
+robustLowerFence = median − k × 1.4826 × MAD
+dendrogramGap = maxGap > medianGap × (1 + k)
+```
+
+At **2.0** (default), findings are moderate. At **3.0**, only strong deviations surface. Below **1.5**, expect many findings. See [Configuration](/configuration) for how to set it.
+
+---
+
+## 2. Embedding Weights — Design Intent (11 constants)
+
+These weights control how text facets blend into identity and leaf vectors. They are **deliberate design choices** reflecting the relative importance of each signal. They are not arbitrary — they follow a consistent pattern documented below.
+
+### `src/analysis/ingestion/embed/blend.ts`
+
+| Constant               | Value | Role                                             |
+| :--------------------- | :---- | :----------------------------------------------- |
+| `NAME_WEIGHT`          | 0.7   | Name vector in identity computation              |
+| `PATH_WEIGHT`          | 0.3   | Path signal in identity computation              |
+| `IDENTITY_WEIGHT`      | 0.5   | Name+path facet fused with description           |
+| `DESC_WEIGHT`          | 0.7   | Leaf's own description in leaf blending          |
+| `PARENT_SIGNAL_WEIGHT` | 0.3   | Parent file's description signal on a leaf       |
+| `SIG_ONLY_WEIGHT`      | 0.7   | Signature when one auxiliary signal is present   |
+| `SINGLE_SIGNAL_WEIGHT` | 0.3   | The single auxiliary signal (causes or calls)    |
+| `SIG_BOTH_WEIGHT`      | 0.6   | Signature when both causes and calls are present |
+| `CAUSES_BOTH_WEIGHT`   | 0.25  | Causes signal when both auxiliaries are present  |
+| `CALLS_BOTH_WEIGHT`    | 0.15  | Calls signal when both auxiliaries are present   |
+
+### `src/analysis/ingestion/embed/containers.ts`
+
+| Constant          | Value | Role                                            |
+| :---------------- | :---- | :---------------------------------------------- |
+| `IDENTITY_WEIGHT` | 0.5   | Container's own identity vs aggregated children |
+
+### Design pattern
+
+1. **Primary signal dominates at 0.7** — name over path, description over parent, signature over auxiliary.
+2. **Secondary signals complement at 0.3** — enough to shift the vector, not enough to hijack it.
+3. **When two secondaries compete, the split is 0.25 / 0.15** — prioritized by semantic richness (causes describe side effects, calls are weak structural hints).
+4. **Container identity is 50/50** — a directory is half what it says it is (KURAL.md), half what it contains.
+
+### Placement blend weights
+
+`STRUCT_WEIGHT` (0.75) and `VOCAB_WEIGHT` (0.25) in `src/analysis/place/helpers.ts` follow the same logic: structural content is more discriminating than declared identity for routing decisions. `HALF_BLEND` (0.5) is the uninformative prior — equal weight hedges between LCPN-projected and raw cosine similarity when there is no reason to prefer one.
+
+---
+
+## 3. Mathematical Constants (5 constants)
+
+These are derived from formulas. They are not tuning parameters.
+
+| Constant           | Value  | File       | Derivation                                                                        |
+| :----------------- | :----- | :--------- | :-------------------------------------------------------------------------------- |
+| `MAD_SCALE`        | 1.4826 | `fence.ts` | 1/&Phi;&macr;&sup1;(&frac34;) — makes MAD consistent with &sigma; for normal data |
+| `EIGEN_FLOOR`      | 1e-6   | `lcpn.ts`  | Standard numerical precision floor for eigenvalue significance                    |
+| `JACOBI_TOLERANCE` | 1e-10  | `lcpn.ts`  | IEEE double-precision convergence criterion for iterative eigendecomposition      |
+| `QUARTER_TURN`     | &pi;/4 | `lcpn.ts`  | Fallback rotation angle in Jacobi eigenmethod when diagonal elements are equal    |
+| `HALF_MULTIPLIER`  | 0.5    | `lcpn.ts`  | Standard coefficient in Givens rotation formula: 0.5 &times; atan2(...)           |
+
+---
+
+## 4. Definitional Constants (3 constants)
+
+These follow from the definitions of the concepts they implement.
+
+| Constant                   | Value | File               | Why this value                                                                                                                                                                                                                                      |
+| :------------------------- | :---- | :----------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MIN_SUBSTANTIAL_CLUSTERS` | 2     | `bloated.ts`       | You cannot "split" into fewer than 2 groups. This is the definition of a split.                                                                                                                                                                     |
+| `HALF_RATIO`               | 0.5   | `weak-identity.ts` | "Majority" means more than half. A directory with weak identity is one where >50% of children fit an uncle better. This is a safety floor on top of the statistical fence — even if the fence is permissive, a majority must drift before flagging. |
+| `MIN_PROBES`               | 2     | `calibrate.ts`     | `robustLowerFence` returns &minus;&infin; for fewer than 2 values. Fewer than 2 probes means no calibration is statistically possible.                                                                                                              |
+
+---
+
+## 5. Self-Calibrating Thresholds (8 constants)
+
+These values derive from the codebase's own distributions at runtime. None are user-configurable — they adapt automatically, controlled by `k`. See [Audits](/docs/pillars/audits) for each audit's detection logic.
+
+### Placement confidence cascade
+
+The placement engine uses a four-tier decision chain: chain search, alien detection, bridge classification, and safety gating. The `calibrate` function embeds probe descriptions from the codebase, runs them through chain search, and computes all thresholds from those probe distributions.
+
+#### `alienFence` and `hardAlienFence`
+
+```
+alienFence     = robustLowerFence(probeSims, k)
+hardAlienFence = robustLowerFence(probeSims, k + 1)
+```
+
+A query whose best-match similarity falls below `alienFence` is a soft alien. Below `hardAlienFence` (one additional unit of evidence) is a hard alien — so foreign that even soft classification won't help. Both flow through `k`.
+
+#### `safetyGate`
+
+```
+safetyGate = robustLowerFence(probeConfidences, k)
+```
+
+Below what known-good placements achieve at this sensitivity, the engine doesn't have enough confidence to act alone — it escalates to the user.
+
+#### `bridgeThreshold`
+
+```
+bridgeThreshold = safetyGate − MAD(probeConfidences)
+```
+
+If the top path's confidence falls below this, trigger bridge type classification. The gap between `bridgeThreshold` and `safetyGate` is exactly one MAD — the codebase's own natural confidence spread defines the bridge-classification band.
+
+#### Bridge type confidence
+
+```
+confident = top.sim > mean(typeSims) + stddev(typeSims)
+decisive  = gap > stddev(typeSims)
+```
+
+The bridge classifier computes similarities against all 7 reference types. The top type must stand out from alternatives by at least one standard deviation, and the gap between first and second must exceed the natural spread.
+
+### Audit safeguards
+
+#### Incoherent cap
+
+```
+cap = median(allLabelFits)
+fence = min(lowerFence(fits, k), cap)
+```
+
+Caps the incoherence lower fence at the codebase's own median label-fit. For uniformly healthy codebases, the median is high and the cap is tight. For diverse codebases, it's lower and more permissive.
+
+#### Containment floor
+
+```
+containmentFloor = robustLowerFence(dominantSims, k)
+```
+
+Computed from the codebase's own parent-child dominance similarities. This eliminated the `--containmentFloor` CLI flag — one less config field, one less thing to explain.
+
+### Embedding noise floor
+
+#### `MIN_MAD`
+
+```
+MIN_MAD = 0.5 / √d
+```
+
+Floor for Median Absolute Deviation to prevent fence collapse when all values are identical. For d-dimensional unit vectors, random cosine similarity has &sigma; &approx; 1/&radic;d. Half that noise floor means "below this, apparent variation is noise, not signal." For 1536-dim (text-embedding-3-small): 0.0128. For 3072-dim: 0.0090.
+
+---
+
+## 6. Adaptive Temperature (1 constant)
+
+#### Routing temperature
+
+```
+T = 1 / numChildren
+```
+
+Softmax temperature in chain search adapts to the branching factor at each routing step. More children means more decisive routing to avoid probability dilution. For 5 children T=0.2, for 10 children T=0.1. This matches empirically effective ranges without imposing a fixed constant.
+
+---
+
+## 7. Display Preferences (2 constants)
+
+#### `GOOD_THRESHOLD` — currently 0.7
+
+**What:** Score at or above this is displayed in green with "Strong structural fit."
+
+#### `MODERATE_THRESHOLD` — currently 0.4
+
+**What:** Score at or above this is displayed in yellow with "Moderate structural fit." Below is red with "Weak structural fit."
+
+**Why they're here:** These don't affect analysis — they only control terminal colors and verdict text. They're presentation preferences, not algorithmic thresholds.
+
+**How they resolve:** Move to `kural.config.json` as user-configurable display settings. They stop being "unjustified constants in the algorithm" and become "UI defaults the user can change."
+
+---
+
+## Summary
+
+| Category                          |  Count | Resolution                                             |
+| :-------------------------------- | -----: | :----------------------------------------------------- |
+| Single tuning parameter (`k`)     |      1 | User-controlled, governs all fences                    |
+| Embedding weights (design intent) |     13 | Documented rationale, consistent pattern               |
+| Mathematical constants            |      5 | Derived from formulas                                  |
+| Definitional constants            |      3 | Follow from definitions                                |
+| Self-calibrating from data        |      8 | Fence or distribution stat computed at runtime via `k` |
+| Adaptive                          |      1 | Computed per routing step from branching factor        |
+| Display preferences               |      2 | Move to user config                                    |
+| **Total**                         | **33** | **1 tuning parameter, 0 unjustified constants**        |

--- a/src/analysis/audits/context.test.ts
+++ b/src/analysis/audits/context.test.ts
@@ -6,8 +6,6 @@ import type { AuditsConfig } from "../../shell/config/audits.ts";
 const NONE = 0;
 const ONE = 1;
 const SENSITIVITY = 2.0;
-const CONTAINMENT_FLOOR = 0.9;
-const MIN_GROUP = 4;
 
 const EMB_A1 = 0.9;
 const EMB_A2 = 0.1;
@@ -19,8 +17,6 @@ const EMB_B3 = 0.0;
 function makeConfig(overrides: Partial<AuditsConfig> = {}): AuditsConfig {
   return {
     sensitivity: SENSITIVITY,
-    containmentFloor: CONTAINMENT_FLOOR,
-    minGroup: MIN_GROUP,
     ...overrides,
   };
 }
@@ -31,20 +27,6 @@ describe("createContext — basic properties", () => {
     const ctx = createContext(nodes, makeConfig());
 
     expect(ctx.sensitivity).toBe(SENSITIVITY);
-  });
-
-  test("exposes containmentFloor from config", () => {
-    const nodes = toNodeMap();
-    const ctx = createContext(nodes, makeConfig());
-
-    expect(ctx.containmentFloor).toBe(CONTAINMENT_FLOOR);
-  });
-
-  test("exposes minGroup from config", () => {
-    const nodes = toNodeMap();
-    const ctx = createContext(nodes, makeConfig());
-
-    expect(ctx.minGroup).toBe(MIN_GROUP);
   });
 
   test("initializes outlierKeys as empty set", () => {

--- a/src/analysis/audits/context.ts
+++ b/src/analysis/audits/context.ts
@@ -11,6 +11,9 @@ import { collectSiblingPairs } from "./siblings.ts";
 import { findRootNode } from "./types.ts";
 import { upperFence } from "./fence.ts";
 
+/** Minimum group size for statistical tests and cluster detection. */
+const MIN_GROUP = 3;
+
 /** Sibling-pair similarities partitioned by level. */
 type PartitionedSims = { leaf: number[]; file: number[] };
 
@@ -90,8 +93,6 @@ function createContext(
   return {
     nodes,
     sensitivity: config.sensitivity,
-    containmentFloor: config.containmentFloor,
-    minGroup: config.minGroup,
     rootKey: findRootNode(nodes)?.key ?? null,
     axisScores,
     outlierKeys: new Set<string>(),
@@ -132,4 +133,4 @@ function isSuppressed(node: CodeNode, auditName: string): boolean {
   return false;
 }
 
-export { createContext, isSuppressed };
+export { MIN_GROUP, createContext, isSuppressed };

--- a/src/analysis/audits/definitions/bloated.test.ts
+++ b/src/analysis/audits/definitions/bloated.test.ts
@@ -1,8 +1,8 @@
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E01,
   E012,
+  E013,
   E015,
   E018,
   E02,
@@ -14,9 +14,9 @@ import {
   E08,
   E082,
   E085,
+  E087,
   E088,
   E09,
-  MIN_GROUP,
   NONE,
   ONE,
   SENSITIVITY,
@@ -35,8 +35,6 @@ import {
 import { createContext } from "../context.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /**
@@ -47,9 +45,11 @@ const CONFIG = {
 const CLUSTER_A1 = [E09, E01, E0, E0, E0, E0, E0, E0];
 const CLUSTER_A2 = [E085, E015, E0, E0, E0, E0, E0, E0];
 const CLUSTER_A3 = [E088, E012, E0, E0, E0, E0, E0, E0];
+const CLUSTER_A4 = [E087, E013, E0, E0, E0, E0, E0, E0];
 const CLUSTER_B1 = [E0, E0, E0, E0, E0, E09, E01, E0];
 const CLUSTER_B2 = [E0, E0, E0, E0, E0, E085, E015, E0];
 const CLUSTER_B3 = [E0, E0, E0, E0, E0, E088, E012, E0];
+const CLUSTER_B4 = [E0, E0, E0, E0, E0, E087, E013, E0];
 const UNIFORM_A = [E08, E02, E0, E0, E0, E0, E0, E0];
 const UNIFORM_B = [E078, E022, E0, E0, E0, E0, E0, E0];
 const UNIFORM_C = [E082, E018, E0, E0, E0, E0, E0, E0];
@@ -86,17 +86,19 @@ describe("bloated-directories detect — clustered children", () => {
     const f1 = makeFile({ key: "file:/src/a.ts", name: "a.ts", leaf: CLUSTER_A1 });
     const f2 = makeFile({ key: "file:/src/b.ts", name: "b.ts", leaf: CLUSTER_A2 });
     const f3 = makeFile({ key: "file:/src/c.ts", name: "c.ts", leaf: CLUSTER_A3 });
-    const f4 = makeFile({ key: "file:/src/d.ts", name: "d.ts", leaf: CLUSTER_B1 });
-    const f5 = makeFile({ key: "file:/src/e.ts", name: "e.ts", leaf: CLUSTER_B2 });
-    const f6 = makeFile({ key: "file:/src/f.ts", name: "f.ts", leaf: CLUSTER_B3 });
+    const f4 = makeFile({ key: "file:/src/d.ts", name: "d.ts", leaf: CLUSTER_A4 });
+    const f5 = makeFile({ key: "file:/src/e.ts", name: "e.ts", leaf: CLUSTER_B1 });
+    const f6 = makeFile({ key: "file:/src/f.ts", name: "f.ts", leaf: CLUSTER_B2 });
+    const f7 = makeFile({ key: "file:/src/g.ts", name: "g.ts", leaf: CLUSTER_B3 });
+    const f8 = makeFile({ key: "file:/src/h.ts", name: "h.ts", leaf: CLUSTER_B4 });
     const dir = makeDir({
       key: "dir:/src",
-      childKeys: [f1.key, f2.key, f3.key, f4.key, f5.key, f6.key],
+      childKeys: [f1.key, f2.key, f3.key, f4.key, f5.key, f6.key, f7.key, f8.key],
     });
-    for (const f of [f1, f2, f3, f4, f5, f6]) {
+    for (const f of [f1, f2, f3, f4, f5, f6, f7, f8]) {
       f.parentKey = dir.key;
     }
-    const nodes = toNodeMap(dir, f1, f2, f3, f4, f5, f6);
+    const nodes = toNodeMap(dir, f1, f2, f3, f4, f5, f6, f7, f8);
     const ctx = createContext(nodes, CONFIG);
     const findings = bloatedDirectories.detect(ctx);
 
@@ -200,17 +202,19 @@ describe("bloated-files detect — clustered functions", () => {
     const fn1 = makeFunction({ key: "func:/src/a.ts:a", name: "a", leaf: CLUSTER_A1 });
     const fn2 = makeFunction({ key: "func:/src/a.ts:b", name: "b", leaf: CLUSTER_A2 });
     const fn3 = makeFunction({ key: "func:/src/a.ts:c", name: "c", leaf: CLUSTER_A3 });
-    const fn4 = makeFunction({ key: "func:/src/a.ts:d", name: "d", leaf: CLUSTER_B1 });
-    const fn5 = makeFunction({ key: "func:/src/a.ts:e", name: "e", leaf: CLUSTER_B2 });
-    const fn6 = makeFunction({ key: "func:/src/a.ts:f", name: "f", leaf: CLUSTER_B3 });
+    const fn4 = makeFunction({ key: "func:/src/a.ts:d", name: "d", leaf: CLUSTER_A4 });
+    const fn5 = makeFunction({ key: "func:/src/a.ts:e", name: "e", leaf: CLUSTER_B1 });
+    const fn6 = makeFunction({ key: "func:/src/a.ts:f", name: "f", leaf: CLUSTER_B2 });
+    const fn7 = makeFunction({ key: "func:/src/a.ts:g", name: "g", leaf: CLUSTER_B3 });
+    const fn8 = makeFunction({ key: "func:/src/a.ts:h", name: "h", leaf: CLUSTER_B4 });
     const file = makeFile({
       key: "file:/src/a.ts",
-      childKeys: [fn1.key, fn2.key, fn3.key, fn4.key, fn5.key, fn6.key],
+      childKeys: [fn1.key, fn2.key, fn3.key, fn4.key, fn5.key, fn6.key, fn7.key, fn8.key],
     });
-    for (const fn of [fn1, fn2, fn3, fn4, fn5, fn6]) {
+    for (const fn of [fn1, fn2, fn3, fn4, fn5, fn6, fn7, fn8]) {
       fn.parentKey = file.key;
     }
-    const nodes = toNodeMap(file, fn1, fn2, fn3, fn4, fn5, fn6);
+    const nodes = toNodeMap(file, fn1, fn2, fn3, fn4, fn5, fn6, fn7, fn8);
     const ctx = createContext(nodes, CONFIG);
     const findings = bloatedFiles.detect(ctx);
 

--- a/src/analysis/audits/definitions/bloated.ts
+++ b/src/analysis/audits/definitions/bloated.ts
@@ -5,17 +5,16 @@
  */
 
 import type { AuditContext, Finding, FormatCtx, ListItem } from "../types.ts";
+import { MIN_GROUP, isSuppressed } from "../context.ts";
 import { buildDendrogram, hasSignificantGap } from "../cluster.ts";
 import type { CodeNode } from "../../tree/tree.ts";
 import { defineAudit } from "../types.ts";
 import { getChildrenWithKeys } from "../children.ts";
-import { isSuppressed } from "../context.ts";
 import { num } from "../../../utils/record.ts";
 
 const NONE = 0;
 const NEXT = 1;
 const MIN_SUBSTANTIAL_CLUSTERS = 2;
-const MIN_CLUSTER_SIZE = 3;
 
 /**
  * Renders cluster composition details showing which children should split into separate containers.
@@ -62,7 +61,7 @@ function detectBloated(
   kind: "directory" | "file",
   auditName: string,
 ): Finding[] {
-  const { nodes, sensitivity, minGroup } = ctx;
+  const { nodes, sensitivity } = ctx;
   const findings: Finding[] = [];
   const entries = [...nodes.entries()].filter(
     ([, n]) => n.kind === kind && !n.util && !isSuppressed(n, auditName),
@@ -71,14 +70,14 @@ function detectBloated(
   for (const [key, node] of entries) {
     const cwk = getChildrenWithKeys(node, nodes).filter(({ node: c }) => !c.util && !c.helper);
     const valid = cwk.filter(({ node: c }) => c.leaf.length > NONE);
-    if (valid.length < minGroup) {
+    if (valid.length < MIN_GROUP) {
       continue;
     }
     const result = buildDendrogram(valid.map(({ node: c }) => c.leaf));
     if (!result || !hasSignificantGap(result.merges, sensitivity)) {
       continue;
     }
-    const substantialClusters = result.clusters.filter((c) => c.length >= MIN_CLUSTER_SIZE);
+    const substantialClusters = result.clusters.filter((c) => c.length >= MIN_GROUP);
     if (substantialClusters.length < MIN_SUBSTANTIAL_CLUSTERS) {
       continue;
     }

--- a/src/analysis/audits/definitions/containments.test.ts
+++ b/src/analysis/audits/definitions/containments.test.ts
@@ -1,5 +1,5 @@
+import type { CodeNode, NodeMap } from "../../tree/tree.ts";
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E001,
   E01,
@@ -11,11 +11,9 @@ import {
   E095,
   E099,
   E1,
-  MIN_GROUP,
   NONE,
   SENSITIVITY,
 } from "../../../../tests/constants/audits.ts";
-import type { CodeNode, NodeMap } from "../../tree/tree.ts";
 import { describe, expect, test } from "vite-plus/test";
 import {
   makeFile,
@@ -29,8 +27,6 @@ import { createContext } from "../context.ts";
 
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /** Embeddings: dominant child nearly identical to parent, others distant. */

--- a/src/analysis/audits/definitions/containments.ts
+++ b/src/analysis/audits/definitions/containments.ts
@@ -110,7 +110,8 @@ export default defineAudit({
     const fence = upperFence(gaps, sensitivity);
 
     const dominantSims = entries.map((e) => e.dominantSim);
-    const containmentFloor = robustLowerFence(dominantSims, sensitivity);
+    const computedFloor = robustLowerFence(dominantSims, sensitivity);
+    const containmentFloor = Number.isFinite(computedFloor) ? computedFloor : NONE;
 
     const findings: Finding[] = [];
     for (const e of entries) {

--- a/src/analysis/audits/definitions/containments.ts
+++ b/src/analysis/audits/definitions/containments.ts
@@ -5,6 +5,7 @@
 
 import type { AuditContext, Finding, FormatCtx, ListItem } from "../types.ts";
 import { num, str } from "../../../utils/record.ts";
+import { robustLowerFence, upperFence } from "../fence.ts";
 import type { CodeNode } from "../../tree/tree.ts";
 import { cosineSimilarity } from "../../../utils/vectors.ts";
 import { defineAudit } from "../types.ts";
@@ -13,7 +14,6 @@ import { getChildrenWithKeys } from "../children.ts";
 import { isLeaf } from "../../tree/tree.ts";
 import { isSuppressed } from "../context.ts";
 import { isTypeProducerPair } from "../siblings.ts";
-import { upperFence } from "../fence.ts";
 
 const NONE = 0;
 const NEXT = 1;
@@ -104,10 +104,13 @@ export default defineAudit({
   title: "Containments",
   format: formatContainment,
   detect: (ctx: AuditContext): Finding[] => {
-    const { nodes, sensitivity, containmentFloor } = ctx;
+    const { nodes, sensitivity } = ctx;
     const entries = collectDominanceGaps(nodes);
     const gaps = entries.map((e) => e.gap);
     const fence = upperFence(gaps, sensitivity);
+
+    const dominantSims = entries.map((e) => e.dominantSim);
+    const containmentFloor = robustLowerFence(dominantSims, sensitivity);
 
     const findings: Finding[] = [];
     for (const e of entries) {

--- a/src/analysis/audits/definitions/duplicates.test.ts
+++ b/src/analysis/audits/definitions/duplicates.test.ts
@@ -1,5 +1,4 @@
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E005,
   E006,
@@ -7,7 +6,6 @@ import {
   E094,
   E095,
   E1,
-  MIN_GROUP,
   NONE,
   ONE,
   SENSITIVITY,
@@ -25,8 +23,6 @@ import { createContext } from "../context.ts";
 import duplicates from "./duplicates.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /** Embeddings for cross-file duplicate detection. */

--- a/src/analysis/audits/definitions/focal-drift.test.ts
+++ b/src/analysis/audits/definitions/focal-drift.test.ts
@@ -1,12 +1,10 @@
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E001,
   E01,
   E09,
   E099,
   E1,
-  MIN_GROUP,
   NONE,
   ONE,
   SENSITIVITY,
@@ -23,8 +21,6 @@ import focalDrift from "./focal-drift.ts";
 
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 const PARENT_EMB = [E1, E0, E0];

--- a/src/analysis/audits/definitions/identity-language.test.ts
+++ b/src/analysis/audits/definitions/identity-language.test.ts
@@ -1,5 +1,4 @@
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E01,
   E015,
@@ -9,7 +8,6 @@ import {
   E08,
   E085,
   E09,
-  MIN_GROUP,
   NONE,
   SENSITIVITY,
 } from "../../../../tests/constants/audits.ts";
@@ -25,8 +23,6 @@ import { createContext } from "../context.ts";
 import identityLanguage from "./identity-language.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /** Identity embeddings for axis score tests. */

--- a/src/analysis/audits/definitions/incoherent.test.ts
+++ b/src/analysis/audits/definitions/incoherent.test.ts
@@ -1,5 +1,4 @@
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E005,
   E01,
@@ -23,7 +22,6 @@ import {
   E09,
   E095,
   E1,
-  MIN_GROUP,
   NONE,
   SENSITIVITY,
 } from "../../../../tests/constants/audits.ts";
@@ -40,8 +38,6 @@ import type { CodeNode } from "../../tree/tree.ts";
 import { createContext } from "../context.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /** Identity and leaf embeddings for incoherence testing. */

--- a/src/analysis/audits/definitions/incoherent.ts
+++ b/src/analysis/audits/definitions/incoherent.ts
@@ -5,15 +5,14 @@
 
 import type { AuditContext, Finding, FormatCtx, ListItem } from "../types.ts";
 import { getChildren, isLeaf } from "../../tree/tree.ts";
+import { lowerFence, median } from "../fence.ts";
 import { cosineSimilarity } from "../../../utils/vectors.ts";
 import { defineAudit } from "../types.ts";
 import { fmtPct } from "../../../utils/format.ts";
 import { isSuppressed } from "../context.ts";
-import { lowerFence } from "../fence.ts";
 import { num } from "../../../utils/record.ts";
 
 const NONE = 0;
-const INCOHERENT_CAP = 0.9;
 
 /**
  * Renders the label-fit deficit showing how far a container's declared identity strays from its actual content.
@@ -78,7 +77,8 @@ function detectIncoherent(ctx: AuditContext, utilMode: boolean): Finding[] {
   const { nodes, sensitivity } = ctx;
   const entries = collectLabelFits(nodes, utilMode);
   const fits = entries.map((e) => e.labelFit);
-  const fence = Math.min(lowerFence(fits, sensitivity), INCOHERENT_CAP);
+  const cap = median(fits);
+  const fence = Math.min(lowerFence(fits, sensitivity), cap);
   const auditName = utilMode ? "incoherent-utils" : "incoherent";
 
   const findings: Finding[] = [];

--- a/src/analysis/audits/definitions/incomplete-docs.test.ts
+++ b/src/analysis/audits/definitions/incomplete-docs.test.ts
@@ -1,12 +1,4 @@
-import {
-  CONTAINMENT_FLOOR,
-  MIN_GROUP,
-  NONE,
-  ONE,
-  SENSITIVITY,
-  THREE,
-  TWO,
-} from "../../../../tests/constants/audits.ts";
+import { NONE, ONE, SENSITIVITY, THREE, TWO } from "../../../../tests/constants/audits.ts";
 import { describe, expect, test } from "vite-plus/test";
 import {
   makeDir,
@@ -21,8 +13,6 @@ import { createContext } from "../context.ts";
 import incompleteDocs from "./incomplete-docs.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 describe("incomplete-docs detect — function nodes", () => {

--- a/src/analysis/audits/definitions/merge-candidates.test.ts
+++ b/src/analysis/audits/definitions/merge-candidates.test.ts
@@ -1,5 +1,4 @@
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E005,
   E006,
@@ -7,7 +6,6 @@ import {
   E094,
   E095,
   E1,
-  MIN_GROUP,
   NONE,
   ONE,
   SENSITIVITY,
@@ -24,8 +22,6 @@ import { createContext } from "../context.ts";
 import mergeCandidates from "./merge-candidates.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 const EMB_NEAR_A = [E095, E005, E0, E0, E0, E0];

--- a/src/analysis/audits/definitions/misplaced.test.ts
+++ b/src/analysis/audits/definitions/misplaced.test.ts
@@ -1,5 +1,5 @@
+import type { CodeNode, NodeMap } from "../../tree/tree.ts";
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E005,
   E03,
@@ -10,11 +10,9 @@ import {
   E085,
   E095,
   E1,
-  MIN_GROUP,
   NONE,
   SENSITIVITY,
 } from "../../../../tests/constants/audits.ts";
-import type { CodeNode, NodeMap } from "../../tree/tree.ts";
 import { describe, expect, test } from "vite-plus/test";
 import {
   makeDir,
@@ -27,8 +25,6 @@ import { createContext } from "../context.ts";
 import misplaced from "./misplaced.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /** Embedding vectors for misplacement tests. */

--- a/src/analysis/audits/definitions/misplaced.ts
+++ b/src/analysis/audits/definitions/misplaced.ts
@@ -103,6 +103,8 @@ export default defineAudit({
     const raw = collectMisplacedCandidates(nodes);
     const deltas = raw.map((m) => m.delta);
     const fence = upperFence(deltas, sensitivity);
+    // Halved sensitivity → proper fence at the distribution's own center, not halving
+    // the full fence (which would shift both mean and spread terms asymmetrically).
     const outlierFence = upperFence(deltas, sensitivity / OUTLIER_SENSITIVITY_DIVISOR);
     const findings: Finding[] = [];
 

--- a/src/analysis/audits/definitions/misplaced.ts
+++ b/src/analysis/audits/definitions/misplaced.ts
@@ -14,7 +14,7 @@ import { num } from "../../../utils/record.ts";
 import { upperFence } from "../fence.ts";
 
 const NONE = 0;
-const MISPLACED_HALVE = 2;
+const OUTLIER_SENSITIVITY_DIVISOR = 2;
 
 /**
  * Renders the uncle-fit comparison showing where a node would be better placed in the tree.
@@ -103,6 +103,7 @@ export default defineAudit({
     const raw = collectMisplacedCandidates(nodes);
     const deltas = raw.map((m) => m.delta);
     const fence = upperFence(deltas, sensitivity);
+    const outlierFence = upperFence(deltas, sensitivity / OUTLIER_SENSITIVITY_DIVISOR);
     const findings: Finding[] = [];
 
     for (const m of raw) {
@@ -110,7 +111,7 @@ export default defineAudit({
       if (!node) {
         continue;
       }
-      const effectiveFence = outlierKeys.has(m.nodeKey) ? fence / MISPLACED_HALVE : fence;
+      const effectiveFence = outlierKeys.has(m.nodeKey) ? outlierFence : fence;
       if (m.delta >= effectiveFence && !isSuppressed(node, "misplaced")) {
         findings.push({
           audit: "misplaced",

--- a/src/analysis/audits/definitions/outliers.test.ts
+++ b/src/analysis/audits/definitions/outliers.test.ts
@@ -1,5 +1,4 @@
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E01,
   E012,
@@ -13,7 +12,6 @@ import {
   E088,
   E09,
   E1,
-  MIN_GROUP,
   NONE,
   ONE,
   SENSITIVITY,
@@ -30,8 +28,6 @@ import { createContext } from "../context.ts";
 import outliers from "./outliers.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /** Embedding vectors for similarity tests. */

--- a/src/analysis/audits/definitions/outliers.ts
+++ b/src/analysis/audits/definitions/outliers.ts
@@ -5,12 +5,12 @@
  */
 
 import type { AuditContext, Finding, FormatCtx, ListItem } from "../types.ts";
+import { MIN_GROUP, isSuppressed } from "../context.ts";
 import { avg, cosineSimilarity } from "../../../utils/vectors.ts";
 import { defineAudit } from "../types.ts";
 import { fmtPct } from "../../../utils/format.ts";
 import { getChildrenWithKeys } from "../children.ts";
 import { isLeaf } from "../../tree/tree.ts";
-import { isSuppressed } from "../context.ts";
 import { robustLowerFence } from "../fence.ts";
 
 const NONE = 0;
@@ -60,7 +60,7 @@ export default defineAudit({
   title: "Outliers",
   format: formatOutlier,
   detect: (ctx: AuditContext): Finding[] => {
-    const { nodes, sensitivity, minGroup } = ctx;
+    const { nodes, sensitivity } = ctx;
     const findings: Finding[] = [];
 
     for (const [parentKey, parentNode] of nodes) {
@@ -71,7 +71,7 @@ export default defineAudit({
         ({ node: c }) => !c.util && !c.helper && c.bound === null,
       );
       const valid = cwk.filter(({ node: c }) => c.leaf.length > NONE);
-      if (valid.length < minGroup) {
+      if (valid.length < MIN_GROUP) {
         continue;
       }
 

--- a/src/analysis/audits/definitions/util-duplicates.test.ts
+++ b/src/analysis/audits/definitions/util-duplicates.test.ts
@@ -1,12 +1,10 @@
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E005,
   E006,
   E094,
   E095,
   E1,
-  MIN_GROUP,
   NONE,
   ONE,
   SENSITIVITY,
@@ -17,8 +15,6 @@ import { createContext } from "../context.ts";
 import { utilDuplicates as duplicateUtils } from "./duplicates.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /** Embeddings for util duplicate detection. */

--- a/src/analysis/audits/definitions/vocabulary-bleed.test.ts
+++ b/src/analysis/audits/definitions/vocabulary-bleed.test.ts
@@ -1,5 +1,4 @@
 import {
-  CONTAINMENT_FLOOR,
   E0,
   E005,
   E03,
@@ -8,7 +7,6 @@ import {
   E08,
   E095,
   E1,
-  MIN_GROUP,
   NONE,
   SENSITIVITY,
 } from "../../../../tests/constants/audits.ts";
@@ -18,8 +16,6 @@ import { createContext } from "../context.ts";
 import vocabularyBleed from "./vocabulary-bleed.ts";
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /** Identity vectors for vocabulary bleed tests. */

--- a/src/analysis/audits/definitions/weak-identity.test.ts
+++ b/src/analysis/audits/definitions/weak-identity.test.ts
@@ -6,7 +6,6 @@ import {
   E09,
   E095,
   E1,
-  MIN_GROUP,
   NONE,
   SENSITIVITY,
 } from "../../../../tests/constants/audits.ts";
@@ -16,11 +15,8 @@ import type { NodeMap } from "../../tree/tree.ts";
 import { createContext } from "../context.ts";
 import weakIdentity from "./weak-identity.ts";
 
-const CONTAINMENT_FLOOR = 0.9;
 const CONFIG = {
   sensitivity: SENSITIVITY,
-  containmentFloor: CONTAINMENT_FLOOR,
-  minGroup: MIN_GROUP,
 };
 
 /** Vectors for weak-identity tests. */

--- a/src/analysis/audits/detect.test.ts
+++ b/src/analysis/audits/detect.test.ts
@@ -5,12 +5,8 @@ import { detect } from "./detect.ts";
 
 const NONE = 0;
 const DEFAULT_SENSITIVITY = 2.0;
-const DEFAULT_CONTAINMENT_FLOOR = 0.9;
-const DEFAULT_MIN_GROUP = 4;
 const DEFAULT_CONFIG: AuditsConfig = {
   sensitivity: DEFAULT_SENSITIVITY,
-  containmentFloor: DEFAULT_CONTAINMENT_FLOOR,
-  minGroup: DEFAULT_MIN_GROUP,
 };
 
 function makeDir(key: string, name: string, childKeys: string[]): [string, CodeNode] {

--- a/src/analysis/audits/fence.ts
+++ b/src/analysis/audits/fence.ts
@@ -11,17 +11,16 @@ const NONE = 0;
 const MIN_SAMPLE = 2;
 const BESSEL = 1;
 
-/**
- * Half the noise floor of cosine similarity for d-dimensional unit vectors.
- * Random cosine similarity has σ ≈ 1/√d. Below half that, apparent variation
- * is noise, not signal. Default assumes 1536-dim (text-embedding-3-small).
- */
-const DEFAULT_EMBEDDING_DIM = 1536;
-const NOISE_FRACTION = 0.5;
-const MIN_MAD = NOISE_FRACTION / Math.sqrt(DEFAULT_EMBEDDING_DIM);
-
 /** 1/Φ⁻¹(¾) — makes MAD consistent with σ for normal data. */
 const MAD_SCALE = 1.4826;
+
+/** IQR ≈ 2·MAD for normal data — converts IQR to MAD-equivalent scale. */
+const IQR_TO_MAD = 2;
+
+/** Quarter markers for IQR computation. */
+const QUARTILE_FRACTION = 4;
+const LOWER_QUARTILE = 1;
+const UPPER_QUARTILE = 3;
 
 /**
  * Sorts the distribution and picks the middle element as the central tendency.
@@ -53,6 +52,42 @@ function stddev(values: number[], mu: number): number {
     sum += (v - mu) * (v - mu);
   }
   return Math.sqrt(sum / (values.length - BESSEL));
+}
+
+/**
+ * Computes a quartile value via linear interpolation.
+ * @param sorted - Already-sorted array of numbers
+ * @param q - Which quartile (1 for Q1, 3 for Q3)
+ * @returns The interpolated quartile value
+ * @kuralPure
+ * @kuralHelper
+ */
+function quartile(sorted: number[], q: number): number {
+  const pos = (q * (sorted.length - BESSEL)) / QUARTILE_FRACTION;
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  const frac = pos - lo;
+  return sorted[lo] * (BESSEL - frac) + sorted[hi] * frac;
+}
+
+/**
+ * Computes the robust spread estimate for fence computation. Uses MAD as the
+ * primary estimator, falling back to IQR/2 (MAD-equivalent under normality)
+ * when MAD collapses to zero — standard practice in robust statistics.
+ * @param sorted - Already-sorted array of values
+ * @param med - Pre-computed median
+ * @returns MAD value suitable for fence scaling, or 0 if both MAD and IQR are zero
+ * @kuralPure
+ * @kuralHelper
+ */
+function robustSpread(sorted: number[], med: number): number {
+  const deviations = sorted.map((v) => Math.abs(v - med));
+  const mad = median(deviations);
+  if (mad > NONE) {
+    return mad;
+  }
+  const iqr = quartile(sorted, UPPER_QUARTILE) - quartile(sorted, LOWER_QUARTILE);
+  return iqr / IQR_TO_MAD;
 }
 
 /**
@@ -89,6 +124,7 @@ function lowerFence(values: number[], sensitivity: number): number {
 
 /**
  * median - sensitivity·MAD_SCALE·MAD — robust lower fence for small samples.
+ * Falls back to IQR-based spread when MAD is zero.
  * @param values - Distribution of values
  * @param sensitivity - Number of scaled MAD units from the median
  * @returns Robust lower fence, or -Infinity for fewer than 2 values
@@ -99,14 +135,18 @@ function robustLowerFence(values: number[], sensitivity: number): number {
   if (values.length < MIN_SAMPLE) {
     return -Infinity;
   }
-  const med = median(values);
-  const deviations = values.map((v) => Math.abs(v - med));
-  const madValue = Math.max(median(deviations), MIN_MAD);
-  return med - sensitivity * MAD_SCALE * madValue;
+  const sorted = [...values].toSorted((a, b) => a - b);
+  const med = median(sorted);
+  const spread = robustSpread(sorted, med);
+  if (spread === NONE) {
+    return -Infinity;
+  }
+  return med - sensitivity * MAD_SCALE * spread;
 }
 
 /**
  * median + sensitivity·MAD_SCALE·MAD — robust upper fence for small samples.
+ * Falls back to IQR-based spread when MAD is zero.
  * @param values - Distribution of values
  * @param sensitivity - Number of scaled MAD units from the median
  * @returns Robust upper fence, or Infinity for fewer than 2 values
@@ -117,10 +157,13 @@ function robustUpperFence(values: number[], sensitivity: number): number {
   if (values.length < MIN_SAMPLE) {
     return Infinity;
   }
-  const med = median(values);
-  const deviations = values.map((v) => Math.abs(v - med));
-  const madValue = Math.max(median(deviations), MIN_MAD);
-  return med + sensitivity * MAD_SCALE * madValue;
+  const sorted = [...values].toSorted((a, b) => a - b);
+  const med = median(sorted);
+  const spread = robustSpread(sorted, med);
+  if (spread === NONE) {
+    return Infinity;
+  }
+  return med + sensitivity * MAD_SCALE * spread;
 }
 
 export { lowerFence, median, robustLowerFence, robustUpperFence, stddev, upperFence };

--- a/src/analysis/audits/fence.ts
+++ b/src/analysis/audits/fence.ts
@@ -10,7 +10,15 @@ import { avg } from "../../utils/vectors.ts";
 const NONE = 0;
 const MIN_SAMPLE = 2;
 const BESSEL = 1;
-const MIN_MAD = 0.015;
+
+/**
+ * Half the noise floor of cosine similarity for d-dimensional unit vectors.
+ * Random cosine similarity has σ ≈ 1/√d. Below half that, apparent variation
+ * is noise, not signal. Default assumes 1536-dim (text-embedding-3-small).
+ */
+const DEFAULT_EMBEDDING_DIM = 1536;
+const NOISE_FRACTION = 0.5;
+const MIN_MAD = NOISE_FRACTION / Math.sqrt(DEFAULT_EMBEDDING_DIM);
 
 /** 1/Φ⁻¹(¾) — makes MAD consistent with σ for normal data. */
 const MAD_SCALE = 1.4826;

--- a/src/analysis/audits/types.ts
+++ b/src/analysis/audits/types.ts
@@ -32,8 +32,6 @@ type Finding = {
 type AuditContext = {
   readonly nodes: NodeMap;
   readonly sensitivity: number;
-  readonly containmentFloor: number;
-  readonly minGroup: number;
   readonly rootKey: string | null;
   readonly siblingPairs: SiblingPair[];
   readonly leafMergeFence: number;

--- a/src/analysis/place/bridge.ts
+++ b/src/analysis/place/bridge.ts
@@ -7,14 +7,13 @@
 
 import type { CodeNode, NodeMap } from "../tree/tree.ts";
 import { DECIMAL_PLACES, DISPLAY_PATHS, NONE, vecOf } from "./helpers.ts";
+import { avg, cosineSimilarity } from "../../utils/vectors.ts";
 import type { BridgeResult } from "./types.ts";
 import type { PlacementEmbedder } from "./helpers.ts";
-import { cosineSimilarity } from "../../utils/vectors.ts";
 import { getChildren } from "../tree/tree.ts";
+import { stddev } from "../audits/fence.ts";
 
 const NEXT = 1;
-const BRIDGE_TYPE_CONFIDENCE = 0.6;
-const BRIDGE_TYPE_GAP = 0.02;
 
 /** Bridge type reference descriptions. */
 const BRIDGE_TYPE_REFS: Record<string, string> = {
@@ -67,7 +66,11 @@ async function classifyBridgeType(
   const top = sims[NONE];
   const gap = sims.length > NEXT ? top.sim - sims[NEXT].sim : NONE;
   const layer = BRIDGE_TYPE_LAYER[top.type];
-  const confident = top.sim > BRIDGE_TYPE_CONFIDENCE && gap > BRIDGE_TYPE_GAP;
+
+  const allSimValues = sims.map((s) => s.sim);
+  const simMean = avg(allSimValues);
+  const simStd = stddev(allSimValues, simMean);
+  const confident = top.sim > simMean + simStd && gap > simStd;
 
   return {
     type: top.type,

--- a/src/analysis/place/calibrate.test.ts
+++ b/src/analysis/place/calibrate.test.ts
@@ -1,4 +1,4 @@
-import { bestLeafMatch, calibrateAlienFence, classifyAxis } from "./calibrate.ts";
+import { bestLeafMatch, calibrate, classifyAxis } from "./calibrate.ts";
 import { describe, expect, test } from "vite-plus/test";
 import { makeDir, makeFile, makeFunction, toNodeMap } from "../../../tests/helpers/audits.ts";
 
@@ -158,8 +158,8 @@ async function stubEmbedder(texts: string[]): Promise<number[][]> {
   return resolved;
 }
 
-describe("calibrateAlienFence — insufficient probes", () => {
-  test("returns zero fence when fewer than 2 probes", async () => {
+describe("calibrate — insufficient probes", () => {
+  test("returns zero thresholds when fewer than 2 probes", async () => {
     const root = makeDir({
       key: "dir:/src",
       name: "src",
@@ -179,14 +179,14 @@ describe("calibrateAlienFence — insufficient probes", () => {
       description: "Login flow",
     });
     const nodes = toNodeMap(root, auth, file);
-    const result = await calibrateAlienFence(stubEmbedder, nodes, root);
+    const result = await calibrate(stubEmbedder, nodes, root.key, root);
 
     expect(result.alienFence).toBe(NONE);
     expect(result.probeCount).toBe(NONE);
   });
 });
 
-describe("calibrateAlienFence — subdirectory probes", () => {
+describe("calibrate — subdirectory probes", () => {
   test("skips subdirectory with no described files", async () => {
     const root = makeDir({
       key: "dir:/src",
@@ -236,7 +236,7 @@ describe("calibrateAlienFence — subdirectory probes", () => {
       identity: [E1, E0],
     });
     const nodes = toNodeMap(root, dirA, fileA, sub, bare, dirB, fileB, leaf);
-    const result = await calibrateAlienFence(stubEmbedder, nodes, root);
+    const result = await calibrate(stubEmbedder, nodes, root.key, root);
 
     expect(result.probeCount).toBeGreaterThanOrEqual(NEXT);
   });

--- a/src/analysis/place/calibrate.ts
+++ b/src/analysis/place/calibrate.ts
@@ -5,20 +5,25 @@
  * baselines or computes alien fences.
  */
 
+import type { AxisResult, RankedPath } from "./types.ts";
 import type { CodeNode, NodeMap } from "../tree/tree.ts";
-import { NONE, SENSITIVITY } from "./helpers.ts";
+import { DEFAULT_SENSITIVITY, NONE } from "./helpers.ts";
 import { getChildren, isLeaf } from "../tree/tree.ts";
-import type { AxisResult } from "./types.ts";
+import { median, robustLowerFence } from "../audits/fence.ts";
 import type { PlacementEmbedder } from "./helpers.ts";
+import { chainSearch } from "./chain.ts";
 import { cosineSimilarity } from "../../utils/vectors.ts";
-import { robustLowerFence } from "../audits/fence.ts";
 
 const NEXT = 1;
 const MIN_PROBES = 2;
+const SENSITIVITY_INCREMENT = 1;
 
-/** Calibration result with the computed alien fence. */
+/** Calibration result with all self-calibrated placement thresholds. */
 type CalibrationResult = {
   alienFence: number;
+  hardAlienFence: number;
+  safetyGate: number;
+  bridgeThreshold: number;
   probeCount: number;
 };
 
@@ -56,44 +61,84 @@ function selectProbes(
 }
 
 /**
- * Embeds probe descriptions and computes the alien fence from the
- * query-space distribution.
+ * Scores each probe by finding its best leaf match and chain-search confidence.
+ * @param probeVecs - Embedded probe vectors
+ * @param nodes - The full node map
+ * @param rootKey - Key of the root directory
+ * @param root - The root directory node
+ * @returns Parallel arrays of best-match similarities and chain-search confidences
+ * @kuralPure
+ */
+function scoreProbes(
+  probeVecs: number[][],
+  nodes: NodeMap,
+  rootKey: string,
+  root: CodeNode,
+): { probeSims: number[]; probeConfidences: number[] } {
+  const probeSims: number[] = [];
+  const probeConfidences: number[] = [];
+  for (let i = NONE; i < probeVecs.length; i++) {
+    probeSims.push(bestLeafMatch(probeVecs[i], nodes).similarity);
+    const paths: RankedPath[] = chainSearch(probeVecs[i], rootKey, root, nodes);
+    if (paths.length > NONE) {
+      probeConfidences.push(paths[NONE].confidence);
+    }
+  }
+  return { probeSims, probeConfidences };
+}
+
+/**
+ * Computes self-calibrated confidence thresholds from probe distributions.
+ * @param probeSims - Best-match similarities from probes
+ * @param probeConfidences - Chain-search confidences from probes
+ * @returns Alien fences, safety gate, and bridge threshold
+ * @kuralPure
+ */
+function computeThresholds(
+  probeSims: number[],
+  probeConfidences: number[],
+): Omit<CalibrationResult, "probeCount"> {
+  const sensitivity = DEFAULT_SENSITIVITY;
+  const alienFence = robustLowerFence(probeSims, sensitivity);
+  const hardAlienFence = robustLowerFence(probeSims, sensitivity + SENSITIVITY_INCREMENT);
+  const hasConfidence = probeConfidences.length >= MIN_PROBES;
+  const safetyGate = hasConfidence ? robustLowerFence(probeConfidences, sensitivity) : NONE;
+  const confMed = hasConfidence ? median(probeConfidences) : NONE;
+  const confDeviations = probeConfidences.map((v) => Math.abs(v - confMed));
+  const confSpread = hasConfidence ? median(confDeviations) : NONE;
+  const bridgeThreshold = safetyGate - confSpread;
+  return { alienFence, hardAlienFence, safetyGate, bridgeThreshold };
+}
+
+/**
+ * Embeds probe descriptions and computes all self-calibrated placement
+ * thresholds from the codebase's own distributions.
  * @param embedder - Function that embeds text strings into vectors
  * @param nodes - The full node map
+ * @param rootKey - Key of the root directory node
  * @param root - The root directory node
- * @returns Alien fence threshold and probe count
+ * @returns Self-calibrated thresholds for alien, bridge, and safety gating
  * @kuralCauses calls the embedding API via embedder
  */
-async function calibrateAlienFence(
+async function calibrate(
   embedder: PlacementEmbedder,
   nodes: NodeMap,
+  rootKey: string,
   root: CodeNode,
 ): Promise<CalibrationResult> {
   const probes = selectProbes(nodes, root);
   if (probes.length < MIN_PROBES) {
-    return { alienFence: NONE, probeCount: NONE };
+    return {
+      alienFence: NONE,
+      hardAlienFence: NONE,
+      safetyGate: NONE,
+      bridgeThreshold: NONE,
+      probeCount: NONE,
+    };
   }
-
   const probeVecs = await embedder(probes.map((p) => p.description));
-  const probeSims: number[] = [];
-  for (let i = NONE; i < probes.length; i++) {
-    let bestSim = NONE;
-    for (const [, node] of nodes) {
-      if (!isLeaf(node) || node.identity.length === NONE) {
-        continue;
-      }
-      const sim = cosineSimilarity(probeVecs[i], node.identity);
-      if (sim > bestSim) {
-        bestSim = sim;
-      }
-    }
-    probeSims.push(bestSim);
-  }
-
-  return {
-    alienFence: robustLowerFence(probeSims, SENSITIVITY),
-    probeCount: probes.length,
-  };
+  const { probeSims, probeConfidences } = scoreProbes(probeVecs, nodes, rootKey, root);
+  return { ...computeThresholds(probeSims, probeConfidences), probeCount: probes.length };
 }
 
 /**
@@ -144,5 +189,5 @@ function classifyAxis(q: number[], rootNode: CodeNode, nodes: NodeMap): AxisResu
   };
 }
 
-export { bestLeafMatch, calibrateAlienFence, classifyAxis };
+export { bestLeafMatch, calibrate, classifyAxis };
 export type { CalibrationResult };

--- a/src/analysis/place/calibrate.ts
+++ b/src/analysis/place/calibrate.ts
@@ -104,8 +104,9 @@ function computeThresholds(
   const hasConfidence = probeConfidences.length >= MIN_PROBES;
   const safetyGate = hasConfidence ? robustLowerFence(probeConfidences, sensitivity) : NONE;
   const confMed = hasConfidence ? median(probeConfidences) : NONE;
-  const confDeviations = probeConfidences.map((v) => Math.abs(v - confMed));
-  const confSpread = hasConfidence ? median(confDeviations) : NONE;
+  const confSpread = hasConfidence
+    ? median(probeConfidences.map((v) => Math.abs(v - confMed)))
+    : NONE;
   const bridgeThreshold = Math.max(NONE, safetyGate - confSpread);
   return { alienFence, hardAlienFence, safetyGate, bridgeThreshold };
 }

--- a/src/analysis/place/calibrate.ts
+++ b/src/analysis/place/calibrate.ts
@@ -66,7 +66,7 @@ function selectProbes(
  * @param nodes - The full node map
  * @param rootKey - Key of the root directory
  * @param root - The root directory node
- * @returns Parallel arrays of best-match similarities and chain-search confidences
+ * @returns Best-match similarities (one per probe) and chain-search confidences (only for probes where chain search returned paths)
  * @kuralPure
  */
 function scoreProbes(
@@ -106,7 +106,7 @@ function computeThresholds(
   const confMed = hasConfidence ? median(probeConfidences) : NONE;
   const confDeviations = probeConfidences.map((v) => Math.abs(v - confMed));
   const confSpread = hasConfidence ? median(confDeviations) : NONE;
-  const bridgeThreshold = safetyGate - confSpread;
+  const bridgeThreshold = Math.max(NONE, safetyGate - confSpread);
   return { alienFence, hardAlienFence, safetyGate, bridgeThreshold };
 }
 

--- a/src/analysis/place/chain.ts
+++ b/src/analysis/place/chain.ts
@@ -6,9 +6,9 @@
  */
 
 import type { CodeNode, NodeMap } from "../tree/tree.ts";
-import { HALF_BLEND, NONE, PERCENT_SCALE, TEMPERATURE, TOP_PATHS, vecOf } from "./helpers.ts";
+import { HALF_BLEND, NONE, PERCENT_SCALE, TOP_PATHS, vecOf } from "./helpers.ts";
 import type { RankedPath, TrailEntry } from "./types.ts";
-import { cosineSimilarity } from "../../utils/vectors.ts";
+import { avg, cosineSimilarity } from "../../utils/vectors.ts";
 import { isLeaf } from "../tree/tree.ts";
 import { localProject } from "./lcpn.ts";
 
@@ -44,6 +44,20 @@ function blendedScores(q: number[], childVecs: number[][]): number[] {
   });
 }
 
+const MIN_TEMPERATURE = 0.01;
+
+/**
+ * Computes routing temperature from branching factor: more children means
+ * more decisive routing to avoid probability dilution. For 5 children T≈0.2,
+ * for 10 children T≈0.1, matching empirically effective ranges.
+ * @param numChildren - Number of child directories at this routing step
+ * @returns Temperature value scaled to branching factor
+ * @kuralPure
+ */
+function adaptiveTemperature(numChildren: number): number {
+  return Math.max(NEXT / Math.max(numChildren, NEXT), MIN_TEMPERATURE);
+}
+
 /**
  * Converts scores to softmax probabilities with a create-new virtual child.
  * @param scores - Raw blended similarity scores for existing children.
@@ -51,13 +65,14 @@ function blendedScores(q: number[], childVecs: number[][]): number[] {
  * @kuralPure
  */
 function softmaxWithCreateNew(scores: number[]): number[] {
-  const scoreMean = scores.reduce((s, v) => s + v, NONE) / scores.length;
+  const temperature = adaptiveTemperature(scores.length);
+  const scoreMean = avg(scores);
   const scoreStd = Math.sqrt(
     scores.reduce((s, v) => s + (v - scoreMean) ** HALF, NONE) / scores.length,
   );
   const allScores = [...scores, scoreMean + scoreStd];
   const maxScore = Math.max(...allScores);
-  const exps = allScores.map((s) => Math.exp((s - maxScore) / TEMPERATURE));
+  const exps = allScores.map((s) => Math.exp((s - maxScore) / temperature));
   const sumExp = exps.reduce((a, b) => a + b, NONE);
   return exps.map((e) => e / sumExp);
 }

--- a/src/analysis/place/engine.test.ts
+++ b/src/analysis/place/engine.test.ts
@@ -215,14 +215,12 @@ function bridgeEmbedder(): (t: string[]) => Promise<number[][]> {
 }
 
 describe("place — bridge tier", () => {
-  test("reaches bridge-escalation with diluted confidence", async () => {
+  test("places diluted query without alien detection", async () => {
     const nodes = buildDilutedTree();
     const result = await place("generic concept", nodes, bridgeEmbedder());
 
-    expect(result.suggestion.method).toBe("bridge-escalation");
-    expect(result.bridge).not.toBeNull();
-    expect(result.bridge?.type).toBeDefined();
     expect(result.detection.globalAlien).toBe(false);
+    expect(result.suggestion.method).toBeDefined();
   });
 });
 

--- a/src/analysis/place/engine.test.ts
+++ b/src/analysis/place/engine.test.ts
@@ -214,14 +214,131 @@ function bridgeEmbedder(): (t: string[]) => Promise<number[][]> {
   return embed;
 }
 
+/**
+ * Builds a tree where func identity vectors are near-central, decoupling
+ * leaf similarity from routing confidence. Any query has high leaf sim
+ * (avoiding alien detection) while dir identity vectors are spread out
+ * (enabling decisive routing for probes, diluted routing for equidistant query).
+ */
+function buildBridgeTestTree(): NodeMap {
+  const E01 = 0.1;
+  const E02 = 0.2;
+  const E04 = 0.4;
+  const E06 = 0.6;
+  const E08 = 0.8;
+  const F_H = 0.52;
+  const F_M = 0.44;
+  const F_L = 0.38;
+  const F_MH = 0.5;
+  const F_ML = 0.36;
+  const keys = ["a", "b", "c", "d", "e", "f"];
+  const dirVecs = [
+    [E08, E02, E01],
+    [E01, E08, E02],
+    [E02, E01, E08],
+    [E06, E06, E01],
+    [E06, E01, E06],
+    [E01, E06, E06],
+  ];
+  const funcVecs = [
+    [F_H, F_M, F_L],
+    [F_L, F_H, F_M],
+    [F_M, F_L, F_H],
+    [F_MH, F_MH, F_ML],
+    [F_MH, F_ML, F_MH],
+    [F_ML, F_MH, F_MH],
+  ];
+  const root = makeDir({
+    key: "dir:/src",
+    name: "src",
+    identity: [E04, E04, E04],
+    leaf: [E04, E04, E04],
+    childKeys: keys.map((k) => `dir:/src/${k}`),
+    parentKey: null,
+    description: "Root module",
+  });
+  const all: Parameters<typeof toNodeMap> = [root];
+  for (let i = NONE; i < keys.length; i++) {
+    const n = keys[i];
+    all.push(
+      makeDir({
+        key: `dir:/src/${n}`,
+        name: n,
+        identity: dirVecs[i],
+        leaf: dirVecs[i],
+        childKeys: [`file:/src/${n}/f.ts`],
+        parentKey: "dir:/src",
+        description: `Module ${n}`,
+      }),
+      makeFile({
+        key: `file:/src/${n}/f.ts`,
+        name: "f.ts",
+        identity: funcVecs[i],
+        leaf: funcVecs[i],
+        childKeys: [`func:/src/${n}/f.ts:fn`],
+        parentKey: `dir:/src/${n}`,
+        description: `File in ${n}`,
+      }),
+      makeFunction({
+        key: `func:/src/${n}/f.ts:fn`,
+        name: "fn",
+        identity: funcVecs[i],
+        leaf: funcVecs[i],
+        parentKey: `file:/src/${n}/f.ts`,
+      }),
+    );
+  }
+  return toNodeMap(...all);
+}
+
+/**
+ * Stateful embedder for bridge-escalation tests.
+ * Call 1 (probes): biased toward each module → high routing confidence.
+ * Call 2 (query): near-equidistant → diluted confidence below bridge threshold.
+ * Call 3+ (bridge refs): identical non-proportional vectors → confident = false.
+ */
+function bridgeTestEmbedder(): (t: string[]) => Promise<number[][]> {
+  const P_H = 0.7;
+  const P_M = 0.35;
+  const P_L = 0.25;
+  const P_MH = 0.55;
+  const Q = 0.38;
+  const B_H = 0.5;
+  const B_M = 0.4;
+  const B_L = 0.35;
+  let call = NONE;
+  async function embed(texts: string[]): Promise<number[][]> {
+    call++;
+    const PROBE_CALL = 1;
+    const QUERY_CALL = 2;
+    if (call === PROBE_CALL) {
+      return [
+        [P_H, P_M, P_L],
+        [P_L, P_H, P_M],
+        [P_M, P_L, P_H],
+        [P_MH, P_MH, P_L],
+        [P_MH, P_L, P_MH],
+        [P_L, P_MH, P_MH],
+      ];
+    }
+    if (call === QUERY_CALL) {
+      return [[Q, Q, Q]];
+    }
+    const resolved = await Promise.resolve(texts.map(() => [B_H, B_M, B_L]));
+    return resolved;
+  }
+  return embed;
+}
+
 describe("place — bridge tier", () => {
-  test("places diluted query without alien detection", async () => {
-    const nodes = buildDilutedTree();
-    const result = await place("generic concept", nodes, bridgeEmbedder());
+  test("triggers bridge-escalation for diluted query", async () => {
+    const nodes = buildBridgeTestTree();
+    const result = await place("generic concept", nodes, bridgeTestEmbedder());
 
     expect(result.detection.globalAlien).toBe(false);
-    expect(result.suggestion.method).toBeDefined();
-    expect(result.topPaths.length).toBeGreaterThan(NONE);
+    expect(result.suggestion.method).toBe("bridge-escalation");
+    expect(result.bridge).not.toBeNull();
+    expect(result.bridge?.type).toBeDefined();
   });
 });
 

--- a/src/analysis/place/engine.test.ts
+++ b/src/analysis/place/engine.test.ts
@@ -221,6 +221,7 @@ describe("place — bridge tier", () => {
 
     expect(result.detection.globalAlien).toBe(false);
     expect(result.suggestion.method).toBeDefined();
+    expect(result.topPaths.length).toBeGreaterThan(NONE);
   });
 });
 

--- a/src/analysis/place/engine.ts
+++ b/src/analysis/place/engine.ts
@@ -5,21 +5,19 @@
  * into a final suggestion — no other module runs the decision tiers.
  */
 
+import type { BridgeResult, PlacementResult, PlacementSuggestion, RankedPath } from "./types.ts";
 import {
-  BRIDGE_THRESHOLD,
   DECIMAL_PLACES,
   DISPLAY_PATHS,
-  HARD_ALIEN_RATIO,
   NONE,
   PERCENT_SCALE,
-  SAFETY_GATE,
   findCapabilityRoot,
   findRoot,
 } from "./helpers.ts";
-import type { BridgeResult, PlacementResult, PlacementSuggestion, RankedPath } from "./types.ts";
-import { bestLeafMatch, calibrateAlienFence, classifyAxis } from "./calibrate.ts";
+import { bestLeafMatch, calibrate, classifyAxis } from "./calibrate.ts";
 import { buildResult, buildUncertainSuggestion } from "./result.ts";
 import { classifyBridgeType, routeByLayer } from "./bridge.ts";
+import type { CalibrationResult } from "./calibrate.ts";
 import type { NodeMap } from "../tree/tree.ts";
 import type { PlacementEmbedder } from "./helpers.ts";
 import { chainSearch } from "./chain.ts";
@@ -28,9 +26,9 @@ import { findRelatedConcepts } from "./related.ts";
 const NEXT = 1;
 
 /**
- * Determines if the query is alien to the codebase.
+ * Determines if the query is alien to the codebase using self-calibrated thresholds.
  * @param leafSim - Best leaf-level cosine similarity for the query
- * @param alienFence - Calibrated similarity threshold for alien detection
+ * @param cal - Self-calibrated placement thresholds
  * @param topConfidence - Confidence score of the top-ranked path
  * @param topTrailHasCreateNew - Whether the top path's trail includes a create-new step
  * @returns Global and level alien flags
@@ -38,12 +36,12 @@ const NEXT = 1;
  */
 function detectAlien(
   leafSim: number,
-  alienFence: number,
+  cal: CalibrationResult,
   topConfidence: number,
   topTrailHasCreateNew: boolean,
 ): { globalAlien: boolean; levelAlien: boolean } {
-  const hardAlien = leafSim < alienFence * HARD_ALIEN_RATIO;
-  const softAlien = leafSim < alienFence && topConfidence < SAFETY_GATE;
+  const hardAlien = leafSim < cal.hardAlienFence;
+  const softAlien = leafSim < cal.alienFence && topConfidence < cal.safetyGate;
   return {
     globalAlien: hardAlien || softAlien,
     levelAlien: topTrailHasCreateNew,
@@ -137,12 +135,14 @@ function buildBridgeSuggestion(
 
 /**
  * Decides the placement tier and returns the suggestion + optional bridge info.
+ * Uses self-calibrated thresholds from the codebase's own probe distributions.
  * @param alien - Global and level alien detection flags
  * @param topPath - Highest-ranked placement path
  * @param paths - All ranked placement paths from chain search
  * @param leafMatch - Best leaf match similarity and name
  * @param nodes - The scored node map from the snapshot
  * @param root - Root key and node of the tree
+ * @param cal - Self-calibrated placement thresholds
  * @param q - Embedding vector of the query text
  * @param embedder - Function that embeds text strings into vectors
  * @returns Placement suggestion and optional bridge classification info
@@ -155,6 +155,7 @@ async function decideTier(
   leafMatch: { similarity: number; name: string },
   nodes: NodeMap,
   root: { key: string; node: ReturnType<typeof findRoot>["node"] },
+  cal: CalibrationResult,
   q: number[],
   embedder: PlacementEmbedder,
 ): Promise<{ suggestion: PlacementSuggestion; bridgeInfo: BridgeResult | null }> {
@@ -166,13 +167,13 @@ async function decideTier(
     };
   }
 
-  const isBridge = topPath.confidence < BRIDGE_THRESHOLD;
+  const isBridge = topPath.confidence < cal.bridgeThreshold;
   if (isBridge) {
     const bridgeInfo = await classifyBridgeType(embedder, q);
     return { suggestion: buildBridgeSuggestion(bridgeInfo, q, nodes, root, paths), bridgeInfo };
   }
 
-  if (topPath.confidence < SAFETY_GATE) {
+  if (topPath.confidence < cal.safetyGate) {
     return {
       suggestion: buildUncertainSuggestion(paths, nodes, topPath.confidence),
       bridgeInfo: null,
@@ -193,7 +194,7 @@ async function decideTier(
 /** Intermediate signals gathered before the tier decision. */
 type PlaceSignals = {
   root: { key: string; node: ReturnType<typeof findRoot>["node"] };
-  calibration: { alienFence: number; probeCount: number };
+  calibration: CalibrationResult;
   q: number[];
   axis: ReturnType<typeof classifyAxis>;
   leafMatch: { similarity: number; name: string };
@@ -217,7 +218,7 @@ async function gatherSignals(
   embedder: PlacementEmbedder,
 ): Promise<PlaceSignals> {
   const root = findRoot(nodes);
-  const calibration = await calibrateAlienFence(embedder, nodes, root.node);
+  const calibration = await calibrate(embedder, nodes, root.key, root.node);
   const [q] = await embedder([queryText]);
   const axis = classifyAxis(q, root.node, nodes);
   const leafMatch = bestLeafMatch(q, nodes);
@@ -229,12 +230,7 @@ async function gatherSignals(
   const second = paths.length > NEXT ? paths[NEXT] : null;
   const chainGap = second === null ? NEXT : topPath.confidence - second.confidence;
   const hasCreateNew = topPath.trail.some((t) => t.choice === "\u00ABcreate-new\u00BB");
-  const alien = detectAlien(
-    leafMatch.similarity,
-    calibration.alienFence,
-    topPath.confidence,
-    hasCreateNew,
-  );
+  const alien = detectAlien(leafMatch.similarity, calibration, topPath.confidence, hasCreateNew);
 
   return { root, calibration, q, axis, leafMatch, paths, topPath, chainGap, alien };
 }
@@ -260,6 +256,7 @@ async function place(
     s.leafMatch,
     nodes,
     s.root,
+    s.calibration,
     s.q,
     embedder,
   );

--- a/src/analysis/place/helpers.ts
+++ b/src/analysis/place/helpers.ts
@@ -10,11 +10,7 @@ import { getChildren } from "../tree/tree.ts";
 const NONE = 0;
 const STRUCT_WEIGHT = 0.75;
 const VOCAB_WEIGHT = 0.25;
-const SENSITIVITY = 2.0;
-const TEMPERATURE = 0.1;
-const BRIDGE_THRESHOLD = 0.55;
-const SAFETY_GATE = 0.6;
-const HARD_ALIEN_RATIO = 0.88;
+const DEFAULT_SENSITIVITY = 2.0;
 const TOP_K_RELATED = 10;
 const TOP_PATHS = 5;
 const DISPLAY_PATHS = 3;
@@ -68,16 +64,12 @@ function findCapabilityRoot(root: { key: string; node: CodeNode }, nodes: NodeMa
 }
 
 export {
-  BRIDGE_THRESHOLD,
   DECIMAL_PLACES,
+  DEFAULT_SENSITIVITY,
   DISPLAY_PATHS,
   HALF_BLEND,
-  HARD_ALIEN_RATIO,
   NONE,
   PERCENT_SCALE,
-  SAFETY_GATE,
-  SENSITIVITY,
-  TEMPERATURE,
   TOP_K_RELATED,
   TOP_PATHS,
   findCapabilityRoot,

--- a/src/shell/commands/advise/display.ts
+++ b/src/shell/commands/advise/display.ts
@@ -11,6 +11,7 @@ import type {
   ProposedGroup,
 } from "../../../analysis/advise/analyze.ts";
 import { colors, logger } from "../../ui/log.ts";
+import { avg } from "../../../utils/vectors.ts";
 import { renderFooter } from "../../ui/footer.ts";
 
 const NONE = 0;
@@ -46,21 +47,6 @@ function formatDelta(delta: number): string {
 }
 
 /**
- * Computes the arithmetic mean of a number array.
- * @param values - Array of numbers to average
- * @returns The mean value, or zero if the array is empty
- * @kuralPure
- * @kuralHelper
- */
-function average(values: number[]): number {
-  if (values.length === NONE) {
-    return NONE;
-  }
-  const sum = values.reduce((acc, v) => acc + v, NONE);
-  return sum / values.length;
-}
-
-/**
  * Renders a single group with its label and member names.
  * @param group - The proposed group to display
  * @param index - The group number for labeling
@@ -82,9 +68,9 @@ function printScoreDeltas(cut: CutEvaluation, result: AdviseResult): void {
     return;
   }
 
-  const avgFit = average(cut.groups.map((g) => g.childrenFit));
-  const avgUniq = average(cut.groups.map((g) => g.childrenUniqueness));
-  const avgScore = average(cut.groups.map((g) => g.childrenScore));
+  const avgFit = avg(cut.groups.map((g) => g.childrenFit));
+  const avgUniq = avg(cut.groups.map((g) => g.childrenUniqueness));
+  const avgScore = avg(cut.groups.map((g) => g.childrenScore));
 
   logger.log("");
   logger.log(`    ${colors.dim("Current \u2192 Proposed:")}`);

--- a/src/shell/commands/audit/command.ts
+++ b/src/shell/commands/audit/command.ts
@@ -42,8 +42,6 @@ const SHOW_ALL = 0;
  */
 async function runAuditCommand(values: {
   sensitivity?: string;
-  containmentFloor?: string;
-  minGroup?: string;
   filter?: string;
   disable?: string;
   expand?: boolean;
@@ -94,14 +92,6 @@ export default define({
       type: "string" as const,
       short: "k",
       description: "Standard deviations from mean to flag (default: 2.0)",
-    },
-    containmentFloor: {
-      type: "string" as const,
-      description: "Absolute floor for containment detection (default: 0.9)",
-    },
-    minGroup: {
-      type: "string" as const,
-      description: "Minimum group size for statistical tests (default: 4)",
     },
     filter: {
       type: "string" as const,

--- a/src/shell/commands/audit/parse-flags.test.ts
+++ b/src/shell/commands/audit/parse-flags.test.ts
@@ -59,28 +59,13 @@ describe("parseFlags", () => {
 
   it("falls back to defaults when both are absent", () => {
     const DEFAULT_SENSITIVITY = 2.0;
-    const DEFAULT_FLOOR = 0.9;
-    const DEFAULT_GROUP = 4;
     const result = parseFlags({}, {});
     expect(result.sensitivity).toBe(DEFAULT_SENSITIVITY);
-    expect(result.containmentFloor).toBe(DEFAULT_FLOOR);
-    expect(result.minGroup).toBe(DEFAULT_GROUP);
   });
 
   it("passes through negative sensitivity without clamping", () => {
     const result = parseFlags({ sensitivity: "-1" }, {});
     expect(result.sensitivity).toBe(-ONE);
-  });
-
-  it("accepts containmentFloor of 0", () => {
-    const result = parseFlags({ containmentFloor: "0" }, {});
-    expect(result.containmentFloor).toBe(ZERO);
-  });
-
-  it("truncates fractional minGroup via parseInt", () => {
-    const TRUNCATED = 2;
-    const result = parseFlags({ minGroup: "2.5" }, {});
-    expect(result.minGroup).toBe(TRUNCATED);
   });
 
   it("passes through disable from project config", () => {

--- a/src/shell/commands/audit/parse-flags.ts
+++ b/src/shell/commands/audit/parse-flags.ts
@@ -11,9 +11,6 @@ import type { AuditsConfig } from "../../config/audits.ts";
 
 const NONE = 0;
 const DEFAULT_SENSITIVITY = 2.0;
-const DEFAULT_CONTAINMENT_FLOOR = 0.9;
-const DEFAULT_MIN_GROUP = 4;
-const RADIX = 10;
 
 /**
  * Parses a CLI string to a number, returning the fallback when the input is absent or not a number.
@@ -38,16 +35,11 @@ function parseOr(input: string | undefined, fallback: number, radix?: number): n
  * @kuralPure
  */
 function parseFlags(
-  values: { sensitivity?: string; containmentFloor?: string; minGroup?: string },
+  values: { sensitivity?: string },
   baselines: Partial<AuditsConfig>,
 ): AuditsConfig {
   return {
     sensitivity: parseOr(values.sensitivity, baselines.sensitivity ?? DEFAULT_SENSITIVITY),
-    containmentFloor: parseOr(
-      values.containmentFloor,
-      baselines.containmentFloor ?? DEFAULT_CONTAINMENT_FLOOR,
-    ),
-    minGroup: parseOr(values.minGroup, baselines.minGroup ?? DEFAULT_MIN_GROUP, RADIX),
     disable: baselines.disable,
   };
 }
@@ -62,8 +54,6 @@ function parseFlags(
 function parseAuditFlags(
   values: {
     sensitivity?: string;
-    containmentFloor?: string;
-    minGroup?: string;
     disable?: string;
   },
   baselines: Partial<AuditsConfig>,

--- a/src/shell/config/audits.ts
+++ b/src/shell/config/audits.ts
@@ -8,10 +8,6 @@
 type AuditsConfig = {
   /** Standard deviations from the mean to flag (higher = stricter). Default: 2.0 */
   sensitivity: number;
-  /** Absolute floor: containment requires dominant child above this. Default: 0.9 */
-  containmentFloor: number;
-  /** Minimum group size for per-group statistical tests. Default: 4 */
-  minGroup: number;
   /** Audit names to skip (e.g. ["incomplete-docs", "identity-language"]) */
   disable?: string[];
 };

--- a/src/shell/config/validate.test.ts
+++ b/src/shell/config/validate.test.ts
@@ -15,22 +15,14 @@ function auditField(config: Record<string, unknown>, key: string): unknown {
 }
 
 const DEFAULT_SENSITIVITY = 2.0;
-const DEFAULT_FLOOR = 0.9;
-const DEFAULT_GROUP = 4;
 const VALID_SENSITIVITY = 1.5;
-const VALID_FLOOR = 0.8;
-const VALID_GROUP = 5;
 
 /** Builds a valid baseline config for clamp tests. */
 function validConfig(): {
   sensitivity: number;
-  containmentFloor: number;
-  minGroup: number;
 } {
   return {
     sensitivity: VALID_SENSITIVITY,
-    containmentFloor: VALID_FLOOR,
-    minGroup: VALID_GROUP,
   };
 }
 
@@ -39,8 +31,6 @@ describe("clampAudits", () => {
     const { config, warnings } = clampAudits(validConfig());
     expect(warnings).toHaveLength(ZERO);
     expect(config.sensitivity).toBe(VALID_SENSITIVITY);
-    expect(config.containmentFloor).toBe(VALID_FLOOR);
-    expect(config.minGroup).toBe(VALID_GROUP);
   });
 
   it("clamps negative sensitivity to default", () => {
@@ -53,39 +43,6 @@ describe("clampAudits", () => {
   it("clamps zero sensitivity to default", () => {
     const { config, warnings } = clampAudits({ ...validConfig(), sensitivity: ZERO });
     expect(config.sensitivity).toBe(DEFAULT_SENSITIVITY);
-    expect(warnings).toHaveLength(ONE);
-  });
-
-  it("clamps containmentFloor above 1 to default", () => {
-    const OVER = 1.5;
-    const { config, warnings } = clampAudits({ ...validConfig(), containmentFloor: OVER });
-    expect(config.containmentFloor).toBe(DEFAULT_FLOOR);
-    expect(warnings[ZERO]).toContain("containmentFloor must be between 0 and 1");
-  });
-
-  it("clamps negative containmentFloor to default", () => {
-    const NEG = -0.1;
-    const { config, warnings } = clampAudits({ ...validConfig(), containmentFloor: NEG });
-    expect(config.containmentFloor).toBe(DEFAULT_FLOOR);
-    expect(warnings).toHaveLength(ONE);
-  });
-
-  it("accepts containmentFloor of 0", () => {
-    const { config, warnings } = clampAudits({ ...validConfig(), containmentFloor: ZERO });
-    expect(config.containmentFloor).toBe(ZERO);
-    expect(warnings).toHaveLength(ZERO);
-  });
-
-  it("clamps fractional minGroup to default", () => {
-    const FRAC = 2.5;
-    const { config, warnings } = clampAudits({ ...validConfig(), minGroup: FRAC });
-    expect(config.minGroup).toBe(DEFAULT_GROUP);
-    expect(warnings[ZERO]).toContain("minGroup must be a positive integer");
-  });
-
-  it("clamps zero minGroup to default", () => {
-    const { config, warnings } = clampAudits({ ...validConfig(), minGroup: ZERO });
-    expect(config.minGroup).toBe(DEFAULT_GROUP);
     expect(warnings).toHaveLength(ONE);
   });
 
@@ -138,59 +95,6 @@ describe("validateConfig — audits.sensitivity", () => {
     const { config, warnings } = validateConfig({ audits: { sensitivity: VALID } });
     expect(warnings).toHaveLength(ZERO);
     expect(auditField(config, "sensitivity")).toBe(VALID);
-  });
-});
-
-describe("validateConfig — audits.containmentFloor", () => {
-  it("strips negative floor", () => {
-    const { config, warnings } = validateConfig({ audits: { containmentFloor: -0.1 } });
-    expect(warnings[ZERO]).toContain("containmentFloor must be between 0 and 1");
-    expect(auditField(config, "containmentFloor")).toBeUndefined();
-  });
-
-  it("strips floor above 1", () => {
-    const OVER = 1.5;
-    const { config, warnings } = validateConfig({ audits: { containmentFloor: OVER } });
-    expect(warnings[ZERO]).toContain("containmentFloor must be between 0 and 1");
-    expect(auditField(config, "containmentFloor")).toBeUndefined();
-  });
-
-  it("keeps boundary value 0", () => {
-    const { warnings } = validateConfig({ audits: { containmentFloor: 0 } });
-    expect(warnings).toHaveLength(ZERO);
-  });
-
-  it("keeps boundary value 1", () => {
-    const { warnings } = validateConfig({ audits: { containmentFloor: 1 } });
-    expect(warnings).toHaveLength(ZERO);
-  });
-});
-
-describe("validateConfig — audits.minGroup", () => {
-  it("strips zero minGroup", () => {
-    const { config, warnings } = validateConfig({ audits: { minGroup: 0 } });
-    expect(warnings[ZERO]).toContain("minGroup must be a positive integer");
-    expect(auditField(config, "minGroup")).toBeUndefined();
-  });
-
-  it("strips fractional minGroup", () => {
-    const FRAC = 2.5;
-    const { config, warnings } = validateConfig({ audits: { minGroup: FRAC } });
-    expect(warnings[ZERO]).toContain("minGroup must be a positive integer");
-    expect(auditField(config, "minGroup")).toBeUndefined();
-  });
-
-  it("strips negative minGroup", () => {
-    const { config, warnings } = validateConfig({ audits: { minGroup: -3 } });
-    expect(warnings).toHaveLength(ONE);
-    expect(auditField(config, "minGroup")).toBeUndefined();
-  });
-
-  it("keeps valid minGroup", () => {
-    const VALID = 5;
-    const { config, warnings } = validateConfig({ audits: { minGroup: VALID } });
-    expect(warnings).toHaveLength(ZERO);
-    expect(auditField(config, "minGroup")).toBe(VALID);
   });
 });
 

--- a/src/shell/config/validate.ts
+++ b/src/shell/config/validate.ts
@@ -9,13 +9,8 @@
 import type { AuditsConfig } from "./audits.ts";
 
 const MIN_SENSITIVITY = 0;
-const MIN_FLOOR = 0;
-const MAX_FLOOR = 1;
-const MIN_GROUP = 1;
 const NONE = 0;
 const DEFAULT_SENSITIVITY = 2.0;
-const DEFAULT_CONTAINMENT_FLOOR = 0.9;
-const DEFAULT_MIN_GROUP = 4;
 
 type Bag = Record<string, unknown>;
 
@@ -42,28 +37,6 @@ function isValidSensitivity(value: number): boolean {
 }
 
 /**
- * Checks whether a containment floor falls within the zero-to-one range.
- * @param value - Floor ratio to check
- * @returns True when within bounds
- * @kuralPure
- * @kuralHelper
- */
-function isValidFloor(value: number): boolean {
-  return value >= MIN_FLOOR && value <= MAX_FLOOR;
-}
-
-/**
- * Checks whether a minimum group size is a positive integer.
- * @param value - Group size to check
- * @returns True when a valid positive integer
- * @kuralPure
- * @kuralHelper
- */
-function isValidMinGroup(value: number): boolean {
-  return Number.isInteger(value) && value >= MIN_GROUP;
-}
-
-/**
  * Clamps resolved audit parameters to safe defaults when they violate
  * constraints. Returns warnings for each clamped field.
  * @param config - Resolved audit config with potentially invalid values
@@ -73,22 +46,12 @@ function isValidMinGroup(value: number): boolean {
  */
 function clampAudits(config: AuditsConfig): { config: AuditsConfig; warnings: string[] } {
   const warnings: string[] = [];
-  let { sensitivity, containmentFloor, minGroup } = config;
+  let { sensitivity } = config;
   if (!isValidSensitivity(sensitivity)) {
     warnings.push(`sensitivity must be positive (got ${String(sensitivity)}) — using default`);
     sensitivity = DEFAULT_SENSITIVITY;
   }
-  if (!isValidFloor(containmentFloor)) {
-    warnings.push(
-      `containmentFloor must be between 0 and 1 (got ${String(containmentFloor)}) — using default`,
-    );
-    containmentFloor = DEFAULT_CONTAINMENT_FLOOR;
-  }
-  if (!isValidMinGroup(minGroup)) {
-    warnings.push(`minGroup must be a positive integer (got ${String(minGroup)}) — using default`);
-    minGroup = DEFAULT_MIN_GROUP;
-  }
-  return { config: { ...config, sensitivity, containmentFloor, minGroup }, warnings };
+  return { config: { ...config, sensitivity }, warnings };
 }
 
 /**
@@ -105,18 +68,6 @@ function validateAudits(audits: Bag, warnings: string[]): void {
       `audits.sensitivity must be positive (got ${String(audits.sensitivity)}) — using default`,
     );
     delete audits.sensitivity;
-  }
-  if (typeof audits.containmentFloor === "number" && !isValidFloor(audits.containmentFloor)) {
-    warnings.push(
-      `audits.containmentFloor must be between 0 and 1 (got ${String(audits.containmentFloor)}) — using default`,
-    );
-    delete audits.containmentFloor;
-  }
-  if (typeof audits.minGroup === "number" && !isValidMinGroup(audits.minGroup)) {
-    warnings.push(
-      `audits.minGroup must be a positive integer (got ${String(audits.minGroup)}) — using default`,
-    );
-    delete audits.minGroup;
   }
   if ("disable" in audits && Array.isArray(audits.disable)) {
     const strings = audits.disable.filter((v): v is string => typeof v === "string");

--- a/tests/constants/audits.ts
+++ b/tests/constants/audits.ts
@@ -44,8 +44,6 @@ const E1 = 1.0;
 
 /** Common test config values. */
 const SENSITIVITY = 2.0;
-const CONTAINMENT_FLOOR = 0.9;
-const MIN_GROUP = 4;
 
 /** Counting constants. */
 const NONE = 0;
@@ -54,7 +52,6 @@ const TWO = 2;
 const THREE = 3;
 
 export {
-  CONTAINMENT_FLOOR,
   E0,
   E001,
   E005,
@@ -92,7 +89,6 @@ export {
   E095,
   E099,
   E1,
-  MIN_GROUP,
   NONE,
   ONE,
   SENSITIVITY,

--- a/tests/e2e/audit.test.ts
+++ b/tests/e2e/audit.test.ts
@@ -39,7 +39,7 @@ const ONE_PARAM = 1;
 /**
  * Builds a minimal but structurally valid project for the audit pipeline.
  * Two files under one directory, each with one function and sharing a type.
- * Small enough that most audits won't trigger (under minGroup=4),
+ * Small enough that most audits won't trigger (under minGroup=3),
  * letting us test the wiring without engineering specific findings.
  */
 function makeProjectData(root: string): SeedData {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -11,7 +11,7 @@ import type {
 } from "../../src/db/schemas.ts";
 import { closeSnapshot, createActive, openSnapshot } from "../../src/db/snapshot.ts";
 import { execFileSync, execSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -36,11 +36,9 @@ type CliResult = {
  * Returns the absolute path. Caller must clean up via `cleanupTmpRoot`.
  */
 function createTmpRoot(): string {
-  const root = join(
-    tmpdir(),
-    `kural-e2e-${String(Date.now())}-${String(Math.random()).slice(TWO)}`,
-  );
-  mkdirSync(root, { recursive: true });
+  const raw = join(tmpdir(), `kural-e2e-${String(Date.now())}-${String(Math.random()).slice(TWO)}`);
+  mkdirSync(raw, { recursive: true });
+  const root = realpathSync(raw);
   // Strip git env vars leaked by pre-commit hooks (GIT_DIR, GIT_INDEX_FILE, etc.)
   const cleanEnv = Object.fromEntries(
     Object.entries(process.env).filter(([k]) => !k.startsWith("GIT_")),


### PR DESCRIPTION
## Summary

- **Self-calibrate placement thresholds** — replace 6 hardcoded constants (BRIDGE_THRESHOLD, SAFETY_GATE, HARD_ALIEN_RATIO, BRIDGE_TYPE_CONFIDENCE, BRIDGE_TYPE_GAP, TEMPERATURE) with values derived from the codebase's own probe distributions via `calibrate()`
- **Internalize audit constraints** — remove `containmentFloor` and `minGroup` from user-facing config/CLI; containmentFloor now self-calibrates via `robustLowerFence`, minGroup is an internal constant (`MIN_GROUP=3`)
- **Derive MIN_MAD from embedding dimension** — `0.5 / √d` instead of hardcoded 0.015
- **Cap incoherent fence at median** instead of fixed 0.9
- **Use adaptive temperature** (`1/numChildren`) instead of fixed 0.1
- **Reuse `stddev` from fence.ts** in bridge type classification, rename `HALF` → `NOISE_FRACTION` to avoid name collision
- **Replace local `average()`** in advise display with shared `avg()` from vectors.ts
- **Fix macOS e2e snapshot failure** — `realpathSync` the tmpdir to resolve `/var` → `/private/var` symlink mismatch
- **Add tuning docs** to pillars section with cross-references to audits; update Section 5+6 from plan to implemented state
- **Update audits docs** — remove containmentFloor/minGroup from config block, update bloated/incoherent/weak-identity descriptions

## Test plan

- [ ] `vp check` passes (format, lint, types)
- [ ] `vp test` — 918/918 tests pass, 70/70 files, including previously-failing macOS snapshot
- [ ] Verify `kural audit` no longer accepts `--containmentFloor` or `--minGroup` flags
- [ ] Verify `kural place` produces self-calibrated thresholds (check calibration probe count in verbose output)