### PR TITLE
fix: bypass rolldown JSON recursion limit on search index

### DIFF
--- a/docs-site/src/lib/search.ts
+++ b/docs-site/src/lib/search.ts
@@ -2,7 +2,14 @@ import { createElement } from "react";
 import { create, load, search } from "@orama/orama";
 import { createContentHighlighter } from "fumadocs-core/search";
 import { Sparkles } from "lucide-react";
-import searchIndex from "@/data/search-index.json";
+import searchIndexRaw from "@/data/search-index.json?raw";
+
+// Parse at runtime to bypass rolldown's JSON plugin recursion limit
+// on the deeply nested Orama serialized database.
+const searchIndex = JSON.parse(searchIndexRaw) as {
+  pageMeta: Record<string, unknown>;
+  rawData: unknown;
+};
 
 const EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
 const EMBEDDING_DIM = 384;


### PR DESCRIPTION
## Summary

- Import `search-index.json` as a raw string (`?raw`) and parse at runtime with `JSON.parse`
- The serialized Orama database exceeds rolldown's built-in `vite-json` plugin recursion depth, breaking the docs site build after the PR #14 merge added more codebase units to the snapshot

## Root cause

The `builtin:vite-json` plugin in rolldown parses JSON at build time using a Rust parser with a fixed recursion limit. The Orama serialized search index has deeply nested index structures that exceed this limit at column 135201.

## Test plan

- [x] Deploy Docs workflow passes on merge