### PR TITLE
fix(ci): add e2e tests to CI and harden test determinism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,14 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Build CLI for e2e
+        run: pnpm exec vp pack
+
       - name: Unit tests with coverage
         run: pnpm exec vp test --coverage --exclude 'tests/e2e/**'
+
+      - name: E2e tests
+        run: pnpm exec vp test tests/e2e/
 
   build:
     name: Build

--- a/tests/e2e/audit-triggers.test.ts
+++ b/tests/e2e/audit-triggers.test.ts
@@ -344,7 +344,7 @@ describe("identity-language trigger", () => {
           key: "axis-scores:is-does",
           value: JSON.stringify({
             [`dir:${authPath}`]: E08,
-            [`dir:${apiPath}`]: E08,
+            [`dir:${apiPath}`]: E06,
             [`dir:${badPath}`]: E01,
           }),
         },

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -71,6 +71,7 @@ function cleanupTmpRoot(root: string): void {
 /**
  * Spawns `node dist/cli.mjs <args>` with `cwd` set to the given root.
  * Returns stdout, stderr, and exit code. Never throws on non-zero exit.
+ * Forces LC_ALL, LANG, and TZ so date formatting is deterministic across hosts.
  */
 function runCli(args: string[], cwd: string): CliResult {
   try {
@@ -78,7 +79,14 @@ function runCli(args: string[], cwd: string): CliResult {
       cwd,
       encoding: "utf-8",
       stdio: "pipe",
-      env: { ...process.env, NO_COLOR: "1", COLUMNS: "120" },
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+        COLUMNS: "120",
+        LC_ALL: "en_US.UTF-8",
+        LANG: "en_US.UTF-8",
+        TZ: "UTC",
+      },
       timeout: TIMEOUT_MS,
     });
     return { stdout, stderr: "", exitCode: NONE };

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -48,7 +48,7 @@ function createTmpRoot(): string {
   for (let attempt = NONE; attempt < MAX_RETRIES; attempt++) {
     try {
       execSync(
-        "git init -b main && git config commit.gpgsign false && git commit --allow-empty -m init",
+        "git init -b main && git config user.email ci@test && git config user.name ci && git config commit.gpgsign false && git commit --allow-empty -m init",
         gitOpts,
       );
       return root;

--- a/tests/e2e/visual.test.ts
+++ b/tests/e2e/visual.test.ts
@@ -63,8 +63,8 @@ function normalize(stdout: string, root: string): string {
   out = out.replaceAll(/\u001B\[\d+m/g, "");
   // Replace temp root path with placeholder
   out = out.replaceAll(root, "<ROOT>");
-  // Replace locale-formatted dates (e.g., "4/2/2026, 9:43:24 AM")
-  out = out.replaceAll(/\d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2}\s[AP]M/g, "<DATE>");
+  // Replace locale-formatted dates (e.g., "4/2/2026, 9:43:24 AM" or "11/4/2026, 2:02:11 pm").
+  out = out.replaceAll(/\d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2}[\s\u202F]+[AP]M/gi, "<DATE>");
   // Replace ISO dates (e.g., "2026-04-02T...")
   out = out.replaceAll(/\d{4}-\d{2}-\d{2}T[\d:.]+Z/g, "<ISO_DATE>");
   // Replace relative paths that escape the root (../../.../T/kural-e2e-...)


### PR DESCRIPTION
## Summary
- Add CLI build step and e2e test step to the CI test job
- Pin `LC_ALL`, `LANG`, and `TZ` in the e2e test runner for deterministic date formatting across hosts
- Widen the visual test date regex to handle Node ICU whitespace variants (narrow no-break space U+202F)
- Fix identity-language trigger test: identical peer scores collapsed MAD to zero, making the robust fence fall to −∞

## Test plan
- [x] 869 unit tests pass with coverage
- [x] 49 e2e tests pass (including the previously broken identity-language trigger)
- [x] `vp check` clean