### PR TITLE
fix(scoring): rescale cosine inputs before harmonic mean

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,12 +219,12 @@ Kural is a five-stage pipeline:
 
 Every node gets a score card:
 
-- **Fit** — how well the node's content matches its parent's identity (-1...1)
-- **Uniqueness** — mean distance to siblings (-1...1)
-- **Score** — harmonic mean of fit and uniqueness
-- **Children** — direct children quality (containers only)
-- **Subtree** — recursive health of the entire subtree below (containers only)
-- **Overall** — harmonic mean of self and subtree scores
+- **Fit** — how well the node's content matches its parent's identity (raw cosine, -1...1)
+- **Uniqueness** — mean distance to siblings (0...2)
+- **Score** — harmonic mean of normalized fit and uniqueness (0...1)
+- **Children** — direct children quality, containers only (0...1)
+- **Subtree** — recursive health of the entire subtree below, containers only (0...1)
+- **Overall** — harmonic mean of self and subtree scores (0...1)
 
 ## Tech stack
 

--- a/docs/pillars/scoring.md
+++ b/docs/pillars/scoring.md
@@ -194,23 +194,23 @@ The two direct children with the smallest pairwise distance (most similar after 
 
 ## 3. ScoreCard Fields
 
-| Field                | Type                     | Leaf | Container | Description                                               |
-| :------------------- | :----------------------- | :--- | :-------- | :-------------------------------------------------------- |
-| `key`                | string                   | yes  | yes       | Unique node identifier                                    |
-| `kind`               | string                   | yes  | yes       | `"function"`, `"type"`, `"file"`, `"directory"`           |
-| `name`               | string                   | yes  | yes       | Display name                                              |
-| `fit`                | number \| null           | yes  | yes       | Content-to-parent alignment                               |
-| `uniqueness`         | number                   | yes  | yes       | Mean distance to siblings (N/A = 2.0)                     |
-| `score`              | number \| null           | yes  | yes       | harmonicMean(fit, uniqueness)                             |
-| `childrenFit`        | number \| null           | null | yes       | Identity-to-content alignment                             |
-| `childrenUniqueness` | number \| null           | null | yes       | CV spread quality of children (N/A = 2.0)                 |
-| `childrenScore`      | number \| null           | null | yes       | harmonicMean(childrenFit, childrenUniqueness)             |
-| `subtreeFit`         | number \| null           | null | yes       | Mean childrenFit of descendants                           |
-| `subtreeUniqueness`  | number \| null           | null | yes       | Mean childrenUniqueness of descendants                    |
-| `subtreeScore`       | number \| null           | null | yes       | harmonicMean(subtreeFit, subtreeUniqueness)               |
-| `overallScore`       | number \| null           | yes  | yes       | Leaf: score. Container: harmonicMean(score, subtreeScore) |
-| `worstPair`          | [string, string] \| null | null | yes       | Most similar child pair                                   |
-| `bestUncle`          | {name, score} \| null    | yes  | yes       | Best-fitting uncle node                                   |
+| Field                | Type                     | Leaf | Container | Description                                                   |
+| :------------------- | :----------------------- | :--- | :-------- | :------------------------------------------------------------ |
+| `key`                | string                   | yes  | yes       | Unique node identifier                                        |
+| `kind`               | string                   | yes  | yes       | `"function"`, `"type"`, `"file"`, `"directory"`               |
+| `name`               | string                   | yes  | yes       | Display name                                                  |
+| `fit`                | number \| null           | yes  | yes       | Content-to-parent alignment                                   |
+| `uniqueness`         | number                   | yes  | yes       | Mean distance to siblings (N/A = 2.0)                         |
+| `score`              | number \| null           | yes  | yes       | harmonicMean(unitizeCosine(fit), unitizeDistance(uniqueness)) |
+| `childrenFit`        | number \| null           | null | yes       | Identity-to-content alignment                                 |
+| `childrenUniqueness` | number \| null           | null | yes       | CV spread quality of children (N/A = 2.0)                     |
+| `childrenScore`      | number \| null           | null | yes       | harmonicMean(unitizeCosine(childrenFit), childrenUniqueness)  |
+| `subtreeFit`         | number \| null           | null | yes       | Mean childrenFit of descendants                               |
+| `subtreeUniqueness`  | number \| null           | null | yes       | Mean childrenUniqueness of descendants                        |
+| `subtreeScore`       | number \| null           | null | yes       | harmonicMean(unitizeCosine(subtreeFit), subtreeUniqueness)    |
+| `overallScore`       | number \| null           | yes  | yes       | Leaf: score. Container: harmonicMean(score, subtreeScore)     |
+| `worstPair`          | [string, string] \| null | null | yes       | Most similar child pair                                       |
+| `bestUncle`          | {name, score} \| null    | yes  | yes       | Best-fitting uncle node                                       |
 
 ---
 

--- a/docs/pillars/scoring.md
+++ b/docs/pillars/scoring.md
@@ -46,7 +46,7 @@ fit(N) = cosineSimilarity(parent.identity, N.leaf)
 
 How well does this node's content match what its parent claims to be? A function in `src/db/` should have content that aligns with the "db" module's identity.
 
-- Range: [-1, 1] in theory, [0, 1] in practice
+- Range: [-1, 1] (raw cosine); typically positive in practice
 - 1.0 = perfect alignment with parent
 - Null if N has no parent (root node)
 - Null if N is a util container (capability containers have no semantic parent direction)
@@ -71,11 +71,12 @@ How different is this node from its siblings, after factoring out the shared par
 ### score (as a child)
 
 ```
-score(N) = harmonicMean(fit, uniqueness)
+score(N) = harmonicMean(unitizeCosine(fit), unitizeDistance(uniqueness))
 ```
 
-Combined placement quality. The harmonic mean penalizes imbalance — a node needs both good fit and good uniqueness to score well. A well-fitting but non-unique node (duplicate) or a unique but poorly-fitting node (misplaced) both score low.
+Combined placement quality. `fit` is rescaled from [-1, 1] to [0, 1] and `uniqueness` from [0, 2] to [0, 1] before combination (see [§6 Harmonic Mean](#6-harmonic-mean)). The harmonic mean penalizes imbalance — a node needs both good fit and good uniqueness to score well. A well-fitting but non-unique node (duplicate) or a unique but poorly-fitting node (misplaced) both score low.
 
+- Range: [0, 1]
 - Null if fit is null or uniqueness is N/A
 
 ### childrenFit (as a parent)
@@ -123,10 +124,10 @@ How evenly distributed are the container's children? Uses the Coefficient of Var
 ### childrenScore (as a parent)
 
 ```
-childrenScore(N) = harmonicMean(childrenFit, childrenUniqueness)
+childrenScore(N) = harmonicMean(unitizeCosine(childrenFit), childrenUniqueness)
 ```
 
-Combined quality of direct children organization. Null if either input is null or N/A.
+Combined quality of direct children organization. `childrenFit` is rescaled from [-1, 1] to [0, 1]; `childrenUniqueness` is already in (0, 1]. Range: [0, 1]. Null if either input is null or N/A.
 
 ### subtreeFit (subtree root)
 
@@ -154,10 +155,10 @@ Average childrenUniqueness across all descendants. Captures whether children are
 ### subtreeScore (subtree root)
 
 ```
-subtreeScore(N) = harmonicMean(subtreeFit, subtreeUniqueness)
+subtreeScore(N) = harmonicMean(unitizeCosine(subtreeFit), subtreeUniqueness)
 ```
 
-Combined subtree health. Null if either input is null or N/A.
+Combined subtree health. `subtreeFit` is rescaled from [-1, 1] to [0, 1]; `subtreeUniqueness` is already in (0, 1]. Range: [0, 1]. Null if either input is null or N/A.
 
 ### overallScore
 
@@ -235,10 +236,20 @@ Neither measures absolute separation. A folder where all children are uniformly 
 ## 6. Harmonic Mean
 
 ```
-H(a, b) = 2ab / (a + b)
+H(a, b) = 2ab / (a + b)    for a, b ≥ 0
+H(a, b) = 0                if either a ≤ 0 or b ≤ 0
 ```
 
 Used for `score`, `childrenScore`, `subtreeScore`, and `overallScore`. The harmonic mean is stricter than arithmetic mean — it heavily penalizes when one value is much lower than the other. Both metrics must be good for the combined score to be good.
+
+The formula is only well-defined on non-negative inputs; mixed signs or a near-zero sum produce values outside the input range. Raw cosine similarities sit in `[-1, 1]` and per-node uniqueness in `[0, 2]`, so callers rescale first:
+
+```
+unitizeCosine(x)   = (x + 1) / 2   rescales [-1, 1] → [0, 1]
+unitizeDistance(x) = x / 2         rescales [0, 2]  → [0, 1]
+```
+
+All four score fields are therefore strictly in `[0, 1]`.
 
 | a   | b   | H(a,b) | Arithmetic |
 | :-- | :-- | :----- | :--------- |

--- a/src/analysis/advise/analyze.ts
+++ b/src/analysis/advise/analyze.ts
@@ -8,7 +8,14 @@
 
 import type { CodeNode, NodeMap } from "../tree/tree.ts";
 import { HierarchicalClustering, Matrix, cosine, distance_matrix } from "@saehrimnir/druidjs";
-import { avg, centroid, cosineSimilarity, harmonicMean, subtract } from "../../utils/vectors.ts";
+import {
+  avg,
+  centroid,
+  cosineSimilarity,
+  harmonicMean,
+  subtract,
+  unitizeCosine,
+} from "../../utils/vectors.ts";
 import { collectMerges, isHCNode } from "../audits/cluster.ts";
 import { getChildren } from "../tree/tree.ts";
 
@@ -111,7 +118,7 @@ function simulateGroup(members: NamedVector[]): ProposedGroup {
   const groupLeaf = centroid(members.map((m) => m.leaf));
   const childrenFit = cosineSimilarity(groupIdentity, groupLeaf);
   const childrenUniqueness = computeCV(groupIdentity, members);
-  const childrenScore = harmonicMean(childrenFit, childrenUniqueness);
+  const childrenScore = harmonicMean(unitizeCosine(childrenFit), childrenUniqueness);
   return {
     names: members.map((m) => m.name),
     childrenFit,
@@ -215,7 +222,7 @@ function analyzeVectors(items: NamedVector[], parentIdentity: number[]): AdviseR
   const leafVecs = items.map((it) => it.leaf);
   const currentFit = cosineSimilarity(parentIdentity, centroid(leafVecs));
   const currentUniqueness = computeCV(parentIdentity, items);
-  const currentScore = harmonicMean(currentFit, currentUniqueness);
+  const currentScore = harmonicMean(unitizeCosine(currentFit), currentUniqueness);
   const thresholds = generateThresholds(merges);
   const cuts = thresholds.map((t) => evaluateCut(hc, t, items));
   const bestCutIndex = selectBestCut(cuts, currentScore);

--- a/src/analysis/scoring/score.ts
+++ b/src/analysis/scoring/score.ts
@@ -96,6 +96,7 @@ function computeScore(fit: number | null, uniqueness: number): number | null {
   if (fit === null || uniqueness === NO_SIBLINGS) {
     return null;
   }
+  // uniqueness is mean pairwise distance ∈ [0, 2]; rescale to [0, 1].
   return harmonicMean(unitizeCosine(fit), unitizeDistance(uniqueness));
 }
 
@@ -113,6 +114,7 @@ function computeChildrenScore(
   if (childrenFit === null || childrenUniqueness === null) {
     return null;
   }
+  // childrenUniqueness is CV-derived ∈ [0, 1]; no rescale needed.
   return harmonicMean(unitizeCosine(childrenFit), childrenUniqueness);
 }
 
@@ -169,6 +171,7 @@ function computeSubtreeScores(
   const sub = collectSubtree(key, nodes, metrics.childrenFitMap, metrics.childrenUniqMap);
   const { subtreeFit, subtreeUniqueness } = descendantScores(sub, cFit, cUniq);
 
+  // subtreeUniqueness is the mean of CV values ∈ [0, 1]; no rescale needed.
   const subtreeScore =
     subtreeFit === null || subtreeUniqueness === null
       ? null

--- a/src/analysis/scoring/score.ts
+++ b/src/analysis/scoring/score.ts
@@ -15,8 +15,8 @@ import {
 } from "./metrics.ts";
 import { buildTree, getEligibleChildren, isLeaf } from "../tree/tree.ts";
 import { collectSubtree, descendantScores } from "./subtree.ts";
+import { harmonicMean, unitizeCosine, unitizeDistance } from "../../utils/vectors.ts";
 import type { ParseResult } from "../ingestion/parse/pipeline.ts";
-import { harmonicMean } from "../../utils/vectors.ts";
 
 const NONE = 0;
 
@@ -96,7 +96,7 @@ function computeScore(fit: number | null, uniqueness: number): number | null {
   if (fit === null || uniqueness === NO_SIBLINGS) {
     return null;
   }
-  return harmonicMean(fit, uniqueness);
+  return harmonicMean(unitizeCosine(fit), unitizeDistance(uniqueness));
 }
 
 /**
@@ -113,7 +113,7 @@ function computeChildrenScore(
   if (childrenFit === null || childrenUniqueness === null) {
     return null;
   }
-  return harmonicMean(childrenFit, childrenUniqueness);
+  return harmonicMean(unitizeCosine(childrenFit), childrenUniqueness);
 }
 
 /**
@@ -172,7 +172,7 @@ function computeSubtreeScores(
   const subtreeScore =
     subtreeFit === null || subtreeUniqueness === null
       ? null
-      : harmonicMean(subtreeFit, subtreeUniqueness);
+      : harmonicMean(unitizeCosine(subtreeFit), subtreeUniqueness);
 
   return { subtreeFit, subtreeUniqueness, subtreeScore };
 }

--- a/src/shell/commands/score/display.ts
+++ b/src/shell/commands/score/display.ts
@@ -64,10 +64,10 @@ function buildTableRows(
 function printScoreFooter(): void {
   renderFooter(
     [
-      { term: "Self", definition: "how well this node fits under its parent (-1…1)" },
-      { term: "Children", definition: "how coherent this node's direct children are (-1…1)" },
-      { term: "Subtree", definition: "recursive health of the entire subtree below (-1…1)" },
-      { term: "Overall", definition: "harmonic mean of Self and Subtree (-1…1)" },
+      { term: "Self", definition: "how well this node fits under its parent (0…1)" },
+      { term: "Children", definition: "how coherent this node's direct children are (0…1)" },
+      { term: "Subtree", definition: "recursive health of the entire subtree below (0…1)" },
+      { term: "Overall", definition: "harmonic mean of Self and Subtree (0…1)" },
       { term: "(\u2014)", definition: "not applicable (leaves have no Children or Subtree)" },
     ],
     [

--- a/src/utils/vectors.test.ts
+++ b/src/utils/vectors.test.ts
@@ -5,6 +5,8 @@ import {
   harmonicMean,
   pruneOutliers,
   subtract,
+  unitizeCosine,
+  unitizeDistance,
 } from "./vectors.ts";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -278,6 +280,14 @@ const HM_EQUAL = 0.6;
 const HM_HIGH = 0.8;
 const HM_LOW = 0.4;
 
+/** Negative and mixed-sign fixtures for harmonicMean clamping. */
+const NEG_SMALL = -0.2;
+const POS_SMALL = 0.1;
+const NEG_LARGE = -0.5;
+const NEAR_CANCEL_A = 0.5;
+const NEAR_CANCEL_B = -0.49;
+const UNIQ_ABOVE_ONE = 1.5;
+
 describe("harmonicMean", () => {
   it("returns 0 when both inputs are 0", () => {
     expect(harmonicMean(ZERO, ZERO)).toBe(ZERO);
@@ -296,5 +306,50 @@ describe("harmonicMean", () => {
     const hm = harmonicMean(HM_A, HM_B);
     const arithmeticMean = (HM_A + HM_B) / TWO;
     expect(hm).toBeLessThan(arithmeticMean);
+  });
+});
+
+describe("harmonicMean clamping", () => {
+  it("returns 0 when either input is negative (mixed sign)", () => {
+    expect(harmonicMean(HM_HIGH, NEG_SMALL)).toBe(ZERO);
+    expect(harmonicMean(NEG_SMALL, POS_SMALL)).toBe(ZERO);
+  });
+
+  it("returns 0 when both inputs are negative", () => {
+    expect(harmonicMean(NEG_LARGE, NEG_LARGE)).toBe(ZERO);
+  });
+
+  it("does not explode on near-cancellation once clamped", () => {
+    expect(harmonicMean(NEAR_CANCEL_A, NEAR_CANCEL_B)).toBe(ZERO);
+  });
+});
+
+describe("unitizeCosine", () => {
+  it("maps -1 to 0", () => {
+    expect(unitizeCosine(NEGATIVE_ONE)).toBeCloseTo(ZERO, TOLERANCE);
+  });
+
+  it("maps 0 to 0.5", () => {
+    expect(unitizeCosine(ZERO)).toBeCloseTo(HALF, TOLERANCE);
+  });
+
+  it("maps 1 to 1", () => {
+    expect(unitizeCosine(ONE)).toBeCloseTo(ONE, TOLERANCE);
+  });
+});
+
+describe("unitizeDistance", () => {
+  it("maps 0 to 0", () => {
+    expect(unitizeDistance(ZERO)).toBeCloseTo(ZERO, TOLERANCE);
+  });
+
+  it("maps 2 to 1", () => {
+    expect(unitizeDistance(TWO)).toBeCloseTo(ONE, TOLERANCE);
+  });
+
+  it("maps a distance above 1 into (0, 1]", () => {
+    const result = unitizeDistance(UNIQ_ABOVE_ONE);
+    expect(result).toBeLessThanOrEqual(ONE);
+    expect(result).toBeGreaterThan(ZERO);
   });
 });

--- a/src/utils/vectors.ts
+++ b/src/utils/vectors.ts
@@ -116,20 +116,55 @@ function pruneOutliers(vectors: number[][], minSize: number, stddevMultiplier: n
 }
 
 const TWO = 2;
+const ONE = 1;
 
 /**
- * Computes the harmonic mean of two values.
- * Penalizes imbalance — both values must be good to score well.
- * @param a - First value
- * @param b - Second value
- * @returns Harmonic mean, or 0 if either value is 0
+ * Rescales a cosine similarity from [-1, 1] to [0, 1].
+ * Required before harmonic-mean combination, which is only well-defined
+ * on non-negative inputs.
+ * @param value - Cosine similarity in [-1, 1]
+ * @returns Rescaled value in [0, 1]
+ * @kuralPure
+ */
+function unitizeCosine(value: number): number {
+  return (value + ONE) / TWO;
+}
+
+/**
+ * Rescales a pairwise cosine distance from [0, 2] to [0, 1].
+ * Used for per-node uniqueness, which is the mean of (1 − cos) across
+ * sibling pairs and can therefore exceed 1.
+ * @param value - Cosine-distance mean in [0, 2]
+ * @returns Rescaled value in [0, 1]
+ * @kuralPure
+ */
+function unitizeDistance(value: number): number {
+  return value / TWO;
+}
+
+/**
+ * Computes the harmonic mean of two non-negative values. Mixed signs
+ * or a near-zero sum make the formula produce values outside the input
+ * range, so any non-positive input returns 0.
+ * @param a - First value, expected in [0, 1]
+ * @param b - Second value, expected in [0, 1]
+ * @returns Harmonic mean, or 0 if either input is non-positive
  * @kuralPure
  */
 function harmonicMean(a: number, b: number): number {
-  if (a + b === NONE) {
+  if (a <= NONE || b <= NONE) {
     return NONE;
   }
   return (TWO * a * b) / (a + b);
 }
 
-export { avg, centroid, cosineSimilarity, harmonicMean, pruneOutliers, subtract };
+export {
+  avg,
+  centroid,
+  cosineSimilarity,
+  harmonicMean,
+  pruneOutliers,
+  subtract,
+  unitizeCosine,
+  unitizeDistance,
+};

--- a/tests/e2e/__snapshots__/visual.test.ts.snap
+++ b/tests/e2e/__snapshots__/visual.test.ts.snap
@@ -93,10 +93,10 @@ directory · 1 children
 
 Glossary:
 
-Self — how well this node fits under its parent (-1…1)
-Children — how coherent this node's direct children are (-1…1)
-Subtree — recursive health of the entire subtree below (-1…1)
-Overall — harmonic mean of Self and Subtree (-1…1)
+Self — how well this node fits under its parent (0…1)
+Children — how coherent this node's direct children are (0…1)
+Subtree — recursive health of the entire subtree below (0…1)
+Overall — harmonic mean of Self and Subtree (0…1)
 (—) — not applicable (leaves have no Children or Subtree)
 
 Next steps:
@@ -140,10 +140,10 @@ Explanation:
 
 Glossary:
 
-Self — how well this node fits under its parent (-1…1)
-Children — how coherent this node's direct children are (-1…1)
-Subtree — recursive health of the entire subtree below (-1…1)
-Overall — harmonic mean of Self and Subtree (-1…1)
+Self — how well this node fits under its parent (0…1)
+Children — how coherent this node's direct children are (0…1)
+Subtree — recursive health of the entire subtree below (0…1)
+Overall — harmonic mean of Self and Subtree (0…1)
 (—) — not applicable (leaves have no Children or Subtree)
 
 Next steps:


### PR DESCRIPTION
## Summary

- Fixes a math bug in `harmonicMean`: cosine similarities (`fit`, `childrenFit`, `subtreeFit`) sit in `[-1, 1]` and per-node `uniqueness` in `[0, 2]`, but the harmonic mean is only well-defined on non-negative inputs. Mixed signs produced values outside the input range — the worst case being `fit=-0.2, uniqueness=0.1` returning **+0.4** (turning two bad signals into a positive score) and `fit=0.5, uniqueness=-0.49` returning **-49** from near-cancellation.
- Adds `unitizeCosine` and `unitizeDistance` helpers in `src/utils/vectors.ts` and normalizes inputs to `[0, 1]` before every `harmonicMean` call in `score.ts` (3 sites) and `advise/analyze.ts` (2 sites). `harmonicMean` now clamps any non-positive input to `0` as a defensive backstop.
- All four derived score fields (`score`, `childrenScore`, `subtreeScore`, `overallScore`) are now strictly in `[0, 1]`. Updated README, `docs/pillars/scoring.md`, the score footer glossary, and the e2e visual snapshot to reflect the new range.

### Before / after on previously-pathological inputs

| Inputs | Before | After |
|---|---|---|
| fit=−0.2, uniq=0.1 | **+0.4** (sign-inverted) | 0.089 |
| fit=0.8, uniq=−0.3 | **−0.96** (out of range) | 0 (clamped) |
| fit=0.5, uniq=−0.49 | **−49** (near-cancel blowup) | 0 (clamped) |
| fit=0.9, uniq=1.5 | **1.125** (above [0, 1]) | 0.838 |

## Test plan

- [x] `vp check` — format / lint / type-check clean
- [x] `vp test` — 922 / 922 pass (new tests cover mixed-sign, both-negative, near-cancellation, and boundaries of `unitizeCosine` / `unitizeDistance`)
- [x] `vp pack && node dist/cli.mjs snapshot generate src` — 571 items embedded, 595 nodes scored
- [x] `node dist/cli.mjs audit` — **0 structural issues** on `src/`
- [x] `node dist/cli.mjs score` — overall 0.92, all Self/Children/Subtree/Overall columns within `[0, 1]`
- [ ] Reviewer: consider whether MAD fences in any audits were tuned against the old (occasionally negative) score distribution and need re-calibration — the individual `fit` / `uniqueness` fields are unchanged, so audits that use those directly should be unaffected.
- [ ] Reviewer: `kural score -c <pre-fix-snapshot>` against snapshots taken before this change will show large deltas since the score formula shifted; consider regenerating pinned baselines.