### PR TITLE
docs: fix brief link target and architecture frontmatter

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: System overview — pillars, tiers, data model, and sync design
+description: System overview — pillars, tiers, data model, and the embeddings-not-LLMs design choice
 icon: Network
 ---
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -30,7 +30,7 @@ Params are a type system for the structural space. TypeScript types don't patch 
 
 The same way it uses a type checker — to verify its own work before and after writing code. **Brief is the pre-flight check; audit is the post-flight check.**
 
-1. **Before writing code (pre-flight)**: run [`kural brief`](/docs/getting-started) `"description of what I'm about to build"` — get siblings, utilities, symbols, and patterns to reuse or imitate. The agent sees the structural neighborhood before generating anything.
+1. **Before writing code (pre-flight)**: run [`kural brief`](/docs/pillars/place) `"description of what I'm about to build"` — get siblings, utilities, symbols, and patterns to reuse or imitate. The agent sees the structural neighborhood before generating anything.
 2. **Write code** with descriptions following the skill's principles (exclusivity language, no sibling vocabulary, role-based descriptions).
 3. **After writing (post-flight)**: run `kural audit` — surface [findings](/docs/pillars/audits) the way `tsc` surfaces type errors.
 4. **Resolve findings** through the four-phase pipeline: fix incomplete docs first, then documentation quality, then structural issues, then suppress with `@kuralResidual` only as a last resort.


### PR DESCRIPTION
## Summary

Follow-up to #27 — two doc fixes surfaced in review after the merge:

- **`docs/faq.mdx:33`** — the `kural brief` link pointed to `/docs/getting-started`, which doesn't mention the command. Retarget to `/docs/pillars/place`, where brief is documented under "2. `kural brief` — context before implementing".
- **`docs/architecture.mdx:3`** — the frontmatter description still said "sync design" while the intro card on the landing page already mentions the "embeddings-not-LLMs design choice". Align the frontmatter so OG, Twitter, and search-result previews reflect the page's new emphasis.

## Test plan

- [ ] `vp check` and `vp test` pass (green at commit time: 933 unit + 50 e2e)
- [ ] On the rendered docs site, clicking `kural brief` in the FAQ's "How does an AI agent use Kural?" lands on the Place pillar page at the `kural brief` section
- [ ] View page source for `/docs/architecture` and confirm the `<meta name="description">`, `og:description`, and Twitter Card description pull the new text