### PR TITLE
docs(commands): add CLI reference section

### DIFF
--- a/docs/commands/advise.mdx
+++ b/docs/commands/advise.mdx
@@ -1,0 +1,58 @@
+---
+title: kural advise
+description: Analyze a directory's structure and suggest prioritized improvements
+icon: Lightbulb
+---
+
+Analyzes one directory (or a JSON file describing a planned directory) and prints ordered recommendations: what to split, what to merge, what's misplaced, what has weak identity. Use it when `audit` has surfaced too many findings to act on — `advise` distills them into an action plan for one region.
+
+## Synopsis
+
+```bash
+kural advise <path> [flags]
+kural advise --from-file <file> [flags]
+```
+
+## Flags
+
+| Flag                 | Short | Type    | Description                                                                                    |
+| :------------------- | :---- | :------ | :--------------------------------------------------------------------------------------------- |
+| `<path>`             |       | string  | Directory to analyze (positional, required unless `--from-file` is used).                      |
+| `--from-file <file>` | `-f`  | string  | JSON file with `name`/`description` pairs — advises on a planned directory (description mode). |
+| `--leaf`             |       | boolean | Use leaf vectors instead of identity (snapshot mode only).                                     |
+| `--depth <n>`        | `-d`  | string  | Recursion depth into subdirectories. Default `1`.                                              |
+| `--provider <name>`  | `-p`  | string  | Embedding provider — for description mode only.                                                |
+| `--model <id>`       | `-m`  | string  | Model ID override — description mode only.                                                     |
+| `--api-key <key>`    | `-k`  | string  | API key — description mode only.                                                               |
+| `--json`             |       | boolean | Emit results as JSON.                                                                          |
+
+## Examples
+
+Analyze one directory in the current snapshot:
+
+```bash
+kural advise src/analysis/audits
+```
+
+Recurse two levels and use leaf vectors:
+
+```bash
+kural advise src/shell --depth 2 --leaf
+```
+
+Advise on a planned directory described in a JSON file:
+
+```bash
+kural advise --from-file proposed-layout.json
+```
+
+## When to use it
+
+- **When `audit` surfaces many findings at once** — `advise` orders them by impact and groups related ones into a single recommendation.
+- **Before splitting a directory** — description mode lets you feed a proposed layout and see how it scores before writing any code.
+- **During code review**, to produce a short, ordered list of structural issues reviewers can walk through.
+
+## Related
+
+- **Concept:** [Audits](/docs/pillars/audits) — the underlying findings that advise prioritizes.
+- **Companion:** [`kural audit`](/docs/commands/audit) — the unfiltered finding list.

--- a/docs/commands/audit.mdx
+++ b/docs/commands/audit.mdx
@@ -1,0 +1,65 @@
+---
+title: kural audit
+description: Run structural audits on a codebase snapshot and print categorized findings
+icon: SearchCheck
+---
+
+Runs the 14 statistical checks against the current snapshot and prints findings grouped by category — outliers, merge candidates, containments, misplaced nodes, duplicates, vocabulary bleed, incoherent containers, weak identities, and incomplete docs.
+
+## Synopsis
+
+```bash
+kural audit [flags]
+```
+
+`audit` reads the snapshot database in the current working directory. Generate it first with [`kural snapshot generate`](/docs/commands/snapshot).
+
+## Flags
+
+| Flag                | Short | Type    | Description                                                                                            |
+| :------------------ | :---- | :------ | :----------------------------------------------------------------------------------------------------- |
+| `--sensitivity <n>` | `-k`  | number  | Standard deviations from mean to flag a value. Default `2.0`. Higher values = stricter.                |
+| `--filter <list>`   | `-f`  | string  | Comma-separated audit categories to show (e.g. `outliers,duplicates`). Matches against section titles. |
+| `--disable <list>`  | `-d`  | string  | Comma-separated audit names to skip entirely (e.g. `incomplete-docs,vocabulary-bleed`).                |
+| `--expand`          | `-e`  | boolean | Show every finding per audit — disables the default truncation.                                        |
+| `--json`            |       | boolean | Emit machine-readable JSON instead of the formatted report.                                            |
+
+The `sensitivity` and `disable` defaults also come from `.kural/config.json` under the `audits` key — CLI flags override project config. See [Configuration](/docs/configuration).
+
+## Examples
+
+Run all audits at default sensitivity:
+
+```bash
+kural audit
+```
+
+Show only outlier and misplaced findings, with every match expanded:
+
+```bash
+kural audit --filter outliers,misplaced --expand
+```
+
+Stricter threshold, skipping documentation checks:
+
+```bash
+kural audit -k 3.0 -d incomplete-docs
+```
+
+Emit JSON for downstream tooling:
+
+```bash
+kural audit --json > audit.json
+```
+
+## When to use it
+
+- **After regenerating a snapshot**, to see what structural issues the new state introduces.
+- **Before a refactor**, to pick the highest-value target — outliers and duplicates surface move-or-merge candidates directly.
+- **In CI**, via `--json` — consume the report to fail builds on newly introduced findings.
+
+## Related
+
+- **Concept:** [Audits](/docs/pillars/audits) — what each of the 14 checks computes and why.
+- **Suppression:** [Kural Params](/docs/codebase-realities/kural-params) — `@kuralResidual`, `@kuralBound`, and `@kuralHelper` suppress specific audits by design.
+- **Companion:** [`kural score`](/docs/commands/score) — aggregate health numbers that cross-validate with audit findings.

--- a/docs/commands/brief.mdx
+++ b/docs/commands/brief.mdx
@@ -1,0 +1,41 @@
+---
+title: kural brief
+description: Show existing code related to a concept before implementing it
+icon: FileSearch
+---
+
+Given a description of code you plan to write, returns the existing units in the snapshot that are closest in embedding space. Answers _"what already exists in this area?"_ so you don't duplicate behavior or borrow the wrong vocabulary.
+
+## Synopsis
+
+```bash
+kural brief "<description>" [flags]
+```
+
+## Flags
+
+| Flag                | Short | Type    | Description                                                                |
+| :------------------ | :---- | :------ | :------------------------------------------------------------------------- |
+| `<description>`     |       | string  | Description of the code you intend to write (positional, required).        |
+| `--provider <name>` | `-p`  | string  | Embedding provider — `openrouter`, `openai`, `vercel` (default), `ollama`. |
+| `--model <id>`      | `-m`  | string  | Model ID override.                                                         |
+| `--api-key <key>`   | `-k`  | string  | API key. Falls back to `AI_GATEWAY_API_KEY`.                               |
+| `--json`            |       | boolean | Emit the brief as JSON — agent-friendly.                                   |
+
+## Examples
+
+```bash
+kural brief "validate embedding provider configuration"
+kural brief "persist score cards to the snapshot database" --json
+```
+
+## When to use it
+
+- **Before an AI agent writes code**, pipe the brief into its context so it uses existing vocabulary and doesn't re-implement something that lives elsewhere.
+- **When onboarding**, to discover the handful of files that already touch a concept without grep'ing for keywords.
+- **Before opening a PR**, to sanity-check that your change isn't a near-duplicate of code that already exists.
+
+## Related
+
+- **Companion:** [`kural place`](/docs/commands/place) — same input, different question (_where should the new code go?_).
+- **Concept:** [Embedding](/docs/foundation/embedding) — what "close in embedding space" means in this system.

--- a/docs/commands/index.mdx
+++ b/docs/commands/index.mdx
@@ -1,0 +1,37 @@
+---
+title: Overview
+description: CLI reference for every kural command
+icon: Terminal
+---
+
+Each command is one page: synopsis, flags, an example, and when to reach for it. Conceptual background (why the command exists, what it computes) stays in the matching [Concepts](/docs/architecture) page — the reference pages link to it rather than repeat it.
+
+## At a glance
+
+| Command                               | When to use                                                                    |
+| :------------------------------------ | :----------------------------------------------------------------------------- |
+| [`snapshot`](/docs/commands/snapshot) | Bootstrap the repo — parse source, embed every unit, write the local database. |
+| [`brief`](/docs/commands/brief)       | _Before_ writing new code — show what already exists in the area.              |
+| [`place`](/docs/commands/place)       | _Before_ writing new code — rank directories by fit to find its home.          |
+| [`audit`](/docs/commands/audit)       | _After_ writing — list specific structural findings on the updated snapshot.   |
+| [`advise`](/docs/commands/advise)     | Prioritize findings into an ordered action plan for one directory.             |
+| [`score`](/docs/commands/score)       | Track aggregate health over time — fit, uniqueness, children fit/uniqueness.   |
+
+## Typical flow
+
+<Steps>
+  <Step>Run `kural snapshot generate src` on the repo — and again whenever source changes.</Step>
+  <Step>
+    *Before* adding code: use `kural brief` to see what exists, and `kural place` to find its home.
+  </Step>
+  <Step>
+    *After* editing: run `kural audit` for findings, then `kural advise` for a prioritized action
+    plan.
+  </Step>
+  <Step>Use `kural score` to track aggregate health over time — pin snapshots and compare.</Step>
+</Steps>
+
+<Callout type="info">
+  All analysis commands read from the snapshot database — they do not re-embed. Regenerate the
+  snapshot after meaningful code changes so findings stay current.
+</Callout>

--- a/docs/commands/meta.json
+++ b/docs/commands/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Commands",
+  "icon": "Terminal",
+  "defaultOpen": true,
+  "pages": ["index", "snapshot", "brief", "place", "audit", "advise", "score"]
+}

--- a/docs/commands/place.mdx
+++ b/docs/commands/place.mdx
@@ -1,0 +1,45 @@
+---
+title: kural place
+description: Find the directory where new code should live
+icon: MapPin
+---
+
+Takes a natural-language description of code you're about to write, embeds it, and ranks every directory in the snapshot by fit. Answers the core kural question — _where should this code live?_ — before you commit to a path.
+
+## Synopsis
+
+```bash
+kural place "<description>" [flags]
+```
+
+The description is a required positional argument. Quote it so the shell treats it as one argument.
+
+## Flags
+
+| Flag                | Short | Type    | Description                                                                |
+| :------------------ | :---- | :------ | :------------------------------------------------------------------------- |
+| `<description>`     |       | string  | Natural-language description of the code (positional, required).           |
+| `--provider <name>` | `-p`  | string  | Embedding provider — `openrouter`, `openai`, `vercel` (default), `ollama`. |
+| `--model <id>`      | `-m`  | string  | Model ID override.                                                         |
+| `--api-key <key>`   | `-k`  | string  | API key. Falls back to `AI_GATEWAY_API_KEY`.                               |
+| `--json`            |       | boolean | Emit ranked candidates as JSON.                                            |
+
+Use the same provider/model you used for `kural snapshot generate` — vector spaces aren't portable across models.
+
+## Examples
+
+```bash
+kural place "parses CLI flags for the audit command"
+kural place "retries failed HTTP requests with exponential backoff" --json
+```
+
+## When to use it
+
+- **Before adding a new file**, especially when several directories feel plausible.
+- **In an AI coding loop**, to give the agent a ranked list of candidate homes instead of letting it guess.
+- **When refactoring**, to sanity-check where a piece of logic has drifted — if `place` ranks a different directory first than where the code currently lives, you likely have a `misplaced` finding waiting.
+
+## Related
+
+- **Concept:** [Placement](/docs/pillars/place) — how the ranking is computed.
+- **Companion:** [`kural brief`](/docs/commands/brief) — same input, different question (_what already exists in this area?_).

--- a/docs/commands/score.mdx
+++ b/docs/commands/score.mdx
@@ -1,0 +1,57 @@
+---
+title: kural score
+description: Display structural scores and deltas for codebase units
+icon: Gauge
+---
+
+Reads computed health numbers — fit, uniqueness, children fit/uniqueness — from the active snapshot and prints them grouped by level. Optionally compares against another snapshot to show deltas.
+
+## Synopsis
+
+```bash
+kural score [flags]
+```
+
+Requires an existing snapshot — generate one first with [`kural snapshot generate`](/docs/commands/snapshot).
+
+## Flags
+
+| Flag              | Short | Type    | Description                                                                             |
+| :---------------- | :---- | :------ | :-------------------------------------------------------------------------------------- |
+| `--path <prefix>` | `-p`  | string  | Restrict output to units whose path starts with `<prefix>`. Defaults to the whole tree. |
+| `--snapshot <id>` | `-s`  | string  | Snapshot ID or pin name to read. Defaults to the active snapshot.                       |
+| `--compare <id>`  | `-c`  | string  | Snapshot ID or pin name to diff against — renders per-unit deltas in the breakdown.     |
+| `--explain`       | `-e`  | boolean | Show the detailed breakdown table alongside the summary.                                |
+| `--limit <n>`     | `-l`  | string  | Max rows in the breakdown table. Default `20`; `0` for all.                             |
+| `--json`          |       | boolean | Emit the result as JSON.                                                                |
+
+## Examples
+
+Show scores for the whole active snapshot:
+
+```bash
+kural score
+```
+
+Show the detailed breakdown for one directory, top 50 rows:
+
+```bash
+kural score --path src/analysis --explain --limit 50
+```
+
+Diff the current snapshot against the `baseline` pin:
+
+```bash
+kural score --compare baseline --explain
+```
+
+## When to use it
+
+- **Before a refactor**, to know which region is lowest — it's the one that will benefit most.
+- **After a fix**, to check whether the score moved the right way. Pair with [`kural audit`](/docs/commands/audit) — a fix that drops the score but cleared a finding usually introduced a new finding elsewhere.
+- **Compared against a pinned baseline** to track structural drift over a sprint or release cycle.
+
+## Related
+
+- **Concept:** [Scoring](/docs/pillars/scoring) — the definitions of fit, uniqueness, and their children variants.
+- **Companion:** [`kural audit`](/docs/commands/audit) — the finding-level lens that cross-validates score changes.

--- a/docs/commands/snapshot.mdx
+++ b/docs/commands/snapshot.mdx
@@ -1,0 +1,94 @@
+---
+title: kural snapshot
+description: Parse, embed, score, and store a codebase snapshot — plus manage saved snapshots
+icon: Database
+---
+
+Parses source files, embeds every unit, scores the tree, and writes the result to a local SQLite database in `.kural/`. Every other analysis command reads from this snapshot. `snapshot` is a command group with five subcommands — `generate`, `list`, `pin`, `unpin`, `delete`.
+
+## Synopsis
+
+```bash
+kural snapshot <subcommand> [args] [flags]
+```
+
+Run `kural snapshot --help` to list subcommands, or `kural snapshot <subcommand> --help` for flag details.
+
+---
+
+## `snapshot generate`
+
+Runs the full parse → embed → score → store pipeline for a directory.
+
+```bash
+kural snapshot generate <path> [flags]
+```
+
+| Flag                | Short | Type    | Description                                                                |
+| :------------------ | :---- | :------ | :------------------------------------------------------------------------- |
+| `<path>`            |       | string  | Directory to scan (positional, required).                                  |
+| `--provider <name>` | `-p`  | string  | Embedding provider — `openrouter`, `openai`, `vercel` (default), `ollama`. |
+| `--model <id>`      | `-m`  | string  | Model ID override. Uses the provider default when omitted.                 |
+| `--api-key <key>`   | `-k`  | string  | API key. Falls back to `AI_GATEWAY_API_KEY`.                               |
+| `--pin <name>`      |       | string  | Pin this snapshot under `<name>` so automatic eviction won't remove it.    |
+| `--json`            |       | boolean | Emit the result as JSON instead of the human-readable report.              |
+
+```bash
+kural snapshot generate src
+kural snapshot generate src --provider ollama --model qwen3-embedding-4b
+kural snapshot generate src --pin baseline
+```
+
+---
+
+## `snapshot list`
+
+Lists history snapshots for the current git branch with ID, timestamp, and pin name.
+
+```bash
+kural snapshot list [--json]
+```
+
+## `snapshot pin`
+
+Pins a snapshot with a name so it is exempt from automatic eviction.
+
+```bash
+kural snapshot pin <id> <name>
+```
+
+`<id>` can be a snapshot ID or an existing pin name. Both arguments are required.
+
+## `snapshot unpin`
+
+Clears the pin on a snapshot, making it evictable again.
+
+```bash
+kural snapshot unpin <id>
+```
+
+## `snapshot delete`
+
+Permanently removes a snapshot from history.
+
+```bash
+kural snapshot delete <id>
+```
+
+<Callout type="warn">
+  Deletion is immediate and cannot be undone. If the snapshot is the only one on the branch, every
+  other analysis command will have nothing to read until you run `generate` again.
+</Callout>
+
+---
+
+## When to use it
+
+- **Once per repo** to bootstrap, then **after every meaningful code change** to keep findings current.
+- **Pin** long-lived reference snapshots (e.g. `baseline`, `release-v1`) so you can compare scores against them with `kural score --compare`.
+- **Delete** or **unpin** when history clutters up — the eviction policy handles routine cleanup.
+
+## Related
+
+- **Concept:** [Embedding](/docs/foundation/embedding) — how source is turned into vectors.
+- **Companion:** [`kural audit`](/docs/commands/audit), [`kural score`](/docs/commands/score) — read the snapshot this command produces.

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -5,6 +5,7 @@
     "getting-started",
     "configuration",
     "ai-editors",
+    "commands",
     "---Concepts---",
     "architecture",
     "foundation",


### PR DESCRIPTION
## Summary

- Adds a dedicated `Commands` group to the docs sidebar with one reference page per daily-driver command: `snapshot`, `brief`, `place`, `audit`, `advise`, `score`, plus an `Overview` landing page.
- Each page follows a consistent reference shape: synopsis → flags table → examples → when to use → related links. Flag data comes straight from the gunshi `define()` calls so the docs stay faithful to the implementation.
- Sidebar order mirrors expected workflow (`snapshot` → `brief`/`place` → `audit`/`advise` → `score`). `kural skill` is intentionally omitted — it's a one-time setup already covered in `/docs/ai-editors`.
- Content verified against source: flag names/short aliases/types/descriptions/defaults cross-checked against every command's `command.ts`; subcommand list for `snapshot` matches all five entries on disk.

## Test plan

- [ ] `vp run docs:dev` — sidebar shows the new `Commands` group under Guides with the 7 entries in workflow order
- [ ] Every command page loads and renders without console errors
- [ ] Links from the Overview to each command page resolve; links from each command page to its concept/companion pages resolve
- [ ] Flag tables match `kural <command> --help` for each command