### PR TITLE
docs: split planned work into roadmap page; fix faq icon & order

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -1,17 +1,18 @@
 ---
 title: Architecture
-description: System overview — pillars, tiers, data model, and the embeddings-not-LLMs design choice
+description: System overview — pillars, data model, snapshot system, and the embeddings-not-LLMs design choice
 icon: Network
 ---
 
 ## System Overview
 
-Kural is organized around [four pillars](/docs/) — **Embed**, **Score**, **Audit**, **Place** — that cross-validate each other. This page covers the mechanics underneath: how snapshots are built and cached, what the data model looks like, and how local and server tiers sync.
+Kural is organized around [four pillars](/docs/) — **Embed**, **Score**, **Audit**, **Place** — that cross-validate each other. This page covers the mechanics underneath: how snapshots are built and cached, and what the data model looks like.
 
-The system is split into two tiers:
+Today, kural ships as a single tier:
 
-- **CLI** — scan, score, local snapshots
-- **Dashboard (web UI)** — reactive views over snapshot data
+- **CLI** — scan, score, local snapshots on disk under `.kural-db/`.
+
+A server tier and web dashboard are planned — see [Roadmap](/docs/roadmap).
 
 ## How snapshots are built and cached
 
@@ -39,13 +40,11 @@ The consequence: a full embedding pass over a 50k-LOC codebase costs cents at ho
 
 ## Tech Stack
 
-| Layer             | Tool                                                    | Role                                   |
-| ----------------- | ------------------------------------------------------- | -------------------------------------- |
-| CLI framework     | Gunshi                                                  | Command routing, plugin system         |
-| AI                | Multiple providers (Vercel, OpenAI, OpenRouter, Ollama) | Embeddings, advise                     |
-| Local persistence | TanStack DB + node-sqlite-persistence                   | Snapshot storage                       |
-| Cloud backend     | Turso (database-per-project)                            | `active.db` + `history.db` per project |
-| Dashboard         | TanStack DB (React)                                     | Reactive UI over collections           |
+| Layer             | Tool                                                    | Role                           |
+| ----------------- | ------------------------------------------------------- | ------------------------------ |
+| CLI framework     | Gunshi                                                  | Command routing, plugin system |
+| AI                | Multiple providers (Vercel, OpenAI, OpenRouter, Ollama) | Embeddings, advise             |
+| Local persistence | TanStack DB + node-sqlite-persistence                   | Snapshot storage               |
 
 ## Data Model
 
@@ -107,20 +106,10 @@ Format: `<timestamp>-<short-commit-hash>`
       <snapshot-id>.db
 ```
 
-### Server Storage Layout
-
-```
-Turso (<user-id>.kural.io):
-  <project>/
-    <branch>/active.db    # live, clone-able snapshot
-    history.db            # consolidated, all branches + timestamps
-```
-
 ### Snapshot Lifecycle
 
 1. Active snapshot is rotated to `history/<snapshot-id>.db`; a fresh `active.db` is created
 2. Oldest unpinned history snapshots are evicted when count exceeds 10
-3. On the server, only CI writes (via API); developers keep snapshots locally
 
 See [How snapshots are built and cached](#how-snapshots-are-built-and-cached) for the per-run flow.
 
@@ -141,57 +130,15 @@ See [How snapshots are built and cached](#how-snapshots-are-built-and-cached) fo
 
 - `schema_version` is stored in every snapshot's metadata from day one
 - **Additive-only evolution** is the default — new nullable columns only, no removals or renames
-- Old snapshots have NULLs for new columns; dashboard handles gracefully
-- For rare breaking changes, a one-time migration is applied to `history.db`
+- Old snapshots have NULLs for new columns; readers handle them gracefully
+- Breaking changes (rare) require a one-time migration over existing history snapshots
 
 ### Embedding Model Versioning
 
 - `model_id` is stored in snapshot metadata for context
 - Scores are precomputed numbers — no cross-snapshot vector comparison needed
-- If the model changes and scores shift, the dashboard shows the shift; `model_id` explains why
+- If the model changes and scores shift, `model_id` in metadata explains why
 
-## Sync Architecture
+## What's next
 
-### Write Path (CI Only)
-
-```
-CI pipeline -> POST <user-id>.kural.io/api/snapshots
-                  |
-                  v
-              API validates, deduplicates, writes to Turso:
-                - active.db (replace if newer commit)
-                - history.db (append)
-```
-
-- Developers never push to the server — local only
-- CI is the sole writer via authenticated API
-- API is the single writer to Turso — no direct client access
-
-### Concurrency Handling
-
-- Parallel CI runs for different branches: no conflict
-- Parallel CI runs for same branch, same commit: idempotent (skip duplicate)
-- Parallel CI runs for same branch, different commits: latest commit wins, stale rejected (409)
-
-### CI Failure Policy
-
-Fail silently with a warning in CI logs. The snapshot exists locally; next CI run generates a fresh one. No retries or queuing — simplicity over completeness.
-
-## Dashboard
-
-### Branch-Aware Views
-
-The dashboard supports multi-branch, multi-project views:
-
-| View              | Value                                                 |
-| ----------------- | ----------------------------------------------------- |
-| Single branch     | Current structural health                             |
-| Branch comparison | Health diff between branches (e.g., alpha vs release) |
-| Branch timeline   | Trend over history snapshots                          |
-| Pre-merge gate    | Feature branch health vs main                         |
-
-### Data Flow
-
-- TanStack DB (`@tanstack/react-db`) provides reactive live queries over collections
-- Collections are backed by Turso via QueryCollection
-- Live queries update the UI when new snapshots arrive
+Planned work — server tier, cloud sync, and the reactive dashboard — lives on the [Roadmap](/docs/roadmap) page.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: Answers to the questions a skeptic would ask
-icon: HelpCircle
+icon: CircleQuestionMark
 ---
 
 ## Isn't this just another linter?

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -13,7 +13,7 @@
     "codebase-realities",
     "infrastructure",
     "---Reference---",
-    "faq",
-    "roadmap"
+    "roadmap",
+    "faq"
   ]
 }

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -13,6 +13,7 @@
     "codebase-realities",
     "infrastructure",
     "---Reference---",
-    "faq"
+    "faq",
+    "roadmap"
   ]
 }

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -1,0 +1,72 @@
+---
+title: Roadmap
+description: Planned work — server tier, cloud sync, and the reactive dashboard that do not yet exist in code
+icon: Map
+---
+
+<Callout type="info">
+  Everything on this page is planned design, not shipped code. Nothing in `src/` implements a server
+  tier, cloud sync, or a reactive dashboard today — the CLI writes only to local `.kural-db/`.
+  Shipped architecture lives on the [Architecture](/docs/architecture) page.
+</Callout>
+
+## Server tier
+
+Kural today is a single-tier CLI. A server tier is planned so structural snapshots produced in CI can be archived centrally and queried by a web dashboard. Developers would keep writing locally; only CI would push.
+
+### Server Storage Layout
+
+```
+Turso (<user-id>.kural.io):
+  <project>/
+    <branch>/active.db    # live, clone-able snapshot
+    history.db            # consolidated, all branches + timestamps
+```
+
+On the server, only CI writes (via API); developers keep snapshots locally.
+
+## Sync Architecture
+
+### Write Path (CI Only)
+
+```
+CI pipeline -> POST <user-id>.kural.io/api/snapshots
+                  |
+                  v
+              API validates, deduplicates, writes to Turso:
+                - active.db (replace if newer commit)
+                - history.db (append)
+```
+
+- Developers never push to the server — local only
+- CI is the sole writer via authenticated API
+- API is the single writer to Turso — no direct client access
+
+### Concurrency Handling
+
+- Parallel CI runs for different branches: no conflict
+- Parallel CI runs for same branch, same commit: idempotent (skip duplicate)
+- Parallel CI runs for same branch, different commits: latest commit wins, stale rejected (409)
+
+### CI Failure Policy
+
+Fail silently with a warning in CI logs. The snapshot exists locally; next CI run generates a fresh one. No retries or queuing — simplicity over completeness.
+
+## Dashboard
+
+### Branch-Aware Views
+
+The planned dashboard supports multi-branch, multi-project views:
+
+| View              | Value                                                 |
+| ----------------- | ----------------------------------------------------- |
+| Single branch     | Current structural health                             |
+| Branch comparison | Health diff between branches (e.g., alpha vs release) |
+| Branch timeline   | Trend over history snapshots                          |
+| Pre-merge gate    | Feature branch health vs main                         |
+
+### Data Flow
+
+- TanStack DB (`@tanstack/react-db`) provides reactive live queries over collections
+- Collections are backed by Turso via QueryCollection
+- Live queries update the UI when new snapshots arrive


### PR DESCRIPTION
## Summary

- Split `docs/architecture.mdx` so it only describes what ships today (CLI, local `.kural-db/` snapshots, TanStack DB over SQLite, schema). Moved unimplemented server, sync, and dashboard sections into a new `docs/roadmap.mdx` page with a callout that nothing below is shipped.
- Fix FAQ sidebar icon: `HelpCircle` is a top-level lucide-react alias but not keyed in the `icons` index that `docs-site/src/lib/source.ts` validates against — swapped to the canonical `CircleQuestionMark`.
- Reorder `docs/meta.json` so Roadmap precedes FAQ under the Reference section.

## Test plan

- [x] `vp check` passes (format + lint + type)
- [x] `vp test` passes (933 + 50 tests)
- [x] Dev server (`vp run docs:dev`) renders the FAQ icon (`lucide-circle-question-mark`) in the sidebar after a server restart
- [x] Sidebar order is Introduction → Getting Started → Configuration → AI Code Editors → Architecture → Roadmap → FAQ
- [x] `/docs/roadmap` renders the Map icon and the planned-work callout