### PR TITLE
refactor(gateways): hoist findModelRecord into shared http helpers

### DIFF
--- a/src/llms/gateways/http.ts
+++ b/src/llms/gateways/http.ts
@@ -103,6 +103,33 @@ async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
 }
 
 /**
+ * Scans /v1/models' `data` array for the matching model id. Returns the
+ * full model record so the caller can distinguish "model not in catalog"
+ * (undefined) from "model present but pricing sub-record incomplete"
+ * (record returned, pricing field missing).
+ * @param body - Parsed JSON body from the /v1/models response
+ * @param modelId - Exact model id to look up
+ * @returns Model record when found, otherwise undefined
+ * @kuralPure
+ * @kuralUtil
+ */
+function findModelRecord(body: unknown, modelId: string): Record<string, unknown> | undefined {
+  if (!isRecord(body)) {
+    return undefined;
+  }
+  const { data } = body;
+  if (!Array.isArray(data)) {
+    return undefined;
+  }
+  for (const entry of data) {
+    if (isRecord(entry) && entry["id"] === modelId) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Reads the first endpoint record from a /v1/models/{id}/endpoints response
  * so a gateway adapter's throughput reader can pull its p50 fields. Returns
  * undefined when the wrapper, the endpoints array, or its first item are
@@ -128,5 +155,5 @@ function readFirstEndpoint(body: unknown): Record<string, unknown> | undefined {
   return isRecord(first) ? first : undefined;
 }
 
-export { ModelNotFoundError, fetchJson, parsePerToken, readFirstEndpoint };
+export { ModelNotFoundError, fetchJson, findModelRecord, parsePerToken, readFirstEndpoint };
 export type { CatalogEntry, NormalizedThroughput, PricePerMillionTokens };

--- a/src/llms/gateways/openrouter.ts
+++ b/src/llms/gateways/openrouter.ts
@@ -8,7 +8,13 @@
 
 import type { CatalogEntry, NormalizedThroughput, PricePerMillionTokens } from "./http.ts";
 import type { CatalogFetchParams, GatewayAdapter } from "./registry.ts";
-import { ModelNotFoundError, fetchJson, parsePerToken, readFirstEndpoint } from "./http.ts";
+import {
+  ModelNotFoundError,
+  fetchJson,
+  findModelRecord,
+  parsePerToken,
+  readFirstEndpoint,
+} from "./http.ts";
 import { isRecord } from "../../utils/record.ts";
 
 const OPENROUTER_ID = "openrouter";
@@ -55,33 +61,6 @@ function adaptThroughput(endpoint: Record<string, unknown>): NormalizedThroughpu
     return undefined;
   }
   return { ttftSeconds: ttftMs / MS_PER_SECOND, tokensPerSecond: tps };
-}
-
-/**
- * Scans /v1/models' `data` array for the matching model id. Returns the
- * full model record so the caller can distinguish "model not in catalog"
- * (undefined) from "model present but pricing sub-record incomplete"
- * (record returned, pricing field missing).
- * @param body - Parsed JSON body from the /v1/models response
- * @param modelId - Exact model id to look up
- * @returns Model record when found, otherwise undefined
- * @kuralPure
- * @kuralHelper
- */
-function findModelRecord(body: unknown, modelId: string): Record<string, unknown> | undefined {
-  if (!isRecord(body)) {
-    return undefined;
-  }
-  const { data } = body;
-  if (!Array.isArray(data)) {
-    return undefined;
-  }
-  for (const entry of data) {
-    if (isRecord(entry) && entry["id"] === modelId) {
-      return entry;
-    }
-  }
-  return undefined;
 }
 
 /**

--- a/src/llms/gateways/vercel.ts
+++ b/src/llms/gateways/vercel.ts
@@ -9,7 +9,13 @@
 
 import type { CatalogEntry, NormalizedThroughput, PricePerMillionTokens } from "./http.ts";
 import type { CatalogFetchParams, GatewayAdapter } from "./registry.ts";
-import { ModelNotFoundError, fetchJson, parsePerToken, readFirstEndpoint } from "./http.ts";
+import {
+  ModelNotFoundError,
+  fetchJson,
+  findModelRecord,
+  parsePerToken,
+  readFirstEndpoint,
+} from "./http.ts";
 import { isRecord } from "../../utils/record.ts";
 
 const VERCEL_ID = "vercel";
@@ -57,33 +63,6 @@ function adaptThroughput(endpoint: Record<string, unknown>): NormalizedThroughpu
     return undefined;
   }
   return { ttftSeconds: ttftMs / MS_PER_SECOND, tokensPerSecond: tps };
-}
-
-/**
- * Scans /v1/models' `data` array for the matching model id. Returns the
- * full model record so the caller can distinguish "model not in catalog"
- * (undefined) from "model present but pricing sub-record incomplete"
- * (record returned, pricing field missing).
- * @param body - Parsed JSON body from the /v1/models response
- * @param modelId - Exact model id to look up
- * @returns Model record when found, otherwise undefined
- * @kuralPure
- * @kuralHelper
- */
-function findModelRecord(body: unknown, modelId: string): Record<string, unknown> | undefined {
-  if (!isRecord(body)) {
-    return undefined;
-  }
-  const { data } = body;
-  if (!Array.isArray(data)) {
-    return undefined;
-  }
-  for (const entry of data) {
-    if (isRecord(entry) && entry["id"] === modelId) {
-      return entry;
-    }
-  }
-  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `kural audit` flagged `findModelRecord` as a 100% cross-module duplicate between `src/llms/gateways/vercel.ts` and `src/llms/gateways/openrouter.ts` — byte-identical body and JSDoc, both tagged `@kuralPure @kuralHelper`.
- The function reads the OpenAI-compatible `/v1/models` `data` array shape, which is owned by `gateways/http.ts` alongside the structurally identical `readFirstEndpoint` (also `@kuralUtil`). Moving it there is the natural fit, not a new module.
- Hoisted into `http.ts`, retagged `@kuralHelper` → `@kuralUtil` to match `readFirstEndpoint`, and imported from both adapters. Fresh snapshot now reports "No structural issues detected."

## Test plan

- [x] `vp check` passes (format, lint, type-aware)
- [x] `vp test` passes (1069/1069)
- [x] `node dist/cli.mjs snapshot generate src` regenerates snapshot
- [x] `node dist/cli.mjs audit` reports no findings